### PR TITLE
Build _edge_ container images on push to main.

### DIFF
--- a/.github/workflows/build-edge.yml
+++ b/.github/workflows/build-edge.yml
@@ -1,0 +1,46 @@
+name: Build Edge Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/builder/**
+      - apps/controller/**
+      - apps/logstreamer/**
+      - apps/ui/**
+      - apps/api/**
+      - packages/**
+      - package.json
+      - scripts/build-images.sh
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push edge images
+        env:
+          IMAGE_REPO: ghcr.io/${{ github.repository_owner }}
+          TAG: edge
+        run: ./scripts/build-images.sh --push

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -8,13 +8,6 @@ on:
       - apps/builder/**
       - apps/controller/**
       - apps/logstreamer/**
-  push: # Replace with Docker Edge build
-    branches:
-      - main
-    paths:
-      - apps/builder/**
-      - apps/controller/**
-      - apps/logstreamer/**
   workflow_dispatch: 
 
 jobs:

--- a/.github/workflows/build-ts.yaml
+++ b/.github/workflows/build-ts.yaml
@@ -9,14 +9,6 @@ on:
       - apps/api/**
       - packages/**
       - package.json
-  push: # Replace with Docker edge build
-    branches:
-      - main
-    paths:
-      - apps/ui/**
-      - apps/api/**
-      - packages/**
-      - package.json
   workflow_dispatch:
 
 jobs:

--- a/apps/docs/content/docs/getting-started/production.mdx
+++ b/apps/docs/content/docs/getting-started/production.mdx
@@ -11,6 +11,16 @@ import { Callout } from "fumadocs-ui/components/callout"
 
 The default Helm installation is designed to get you up and running quickly — it bundles PostgreSQL and an in-cluster image registry so nothing extra is required. For production use, you should replace both with dedicated external services.
 
+## Keep image versions in sync with the chart
+
+canette is a distributed system — the API, UI, builder, controller, and logstreamer all communicate with each other and share a database schema. Component versions must move together.
+
+The Helm chart handles this automatically: the default `image.tag` is the chart's own `appVersion`, so installing or upgrading the chart always pulls the matching set of images. **Do not override `image.tag` in production unless you have a specific reason to.**
+
+<Callout type="warn">
+  **Never pin to `:edge` in production.** The `edge` tag is rebuilt on every commit to `main` and is not immutable — a pod restart (node eviction, OOM kill, rolling update) can silently pull a newer image and leave your cluster running a mix of incompatible versions. The `edge` tag exists for development and testing against the latest changes only.
+</Callout>
+
 ## Use an external database
 
 The bundled PostgreSQL instance has no persistent storage configured by default and is not suitable for production. Replace it with a managed database or a self-hosted PostgreSQL instance you operate separately.

--- a/apps/docs/content/docs/self-hosting/helm.mdx
+++ b/apps/docs/content/docs/self-hosting/helm.mdx
@@ -43,15 +43,21 @@ helm upgrade --install canette charts/canette \
   --set api.githubClientSecret="<client-secret>"
 ```
 
-Service images default to `ghcr.io/canette/canette/{service}:edge` — no image flags needed for a standard install. Override `image.repo`, `image.tag`, or individual service images as needed:
+Service images default to `ghcr.io/canette/canette/{service}:{appVersion}`, where `appVersion` is the version embedded in the Helm chart. Installing or upgrading the chart automatically uses the matching image versions — no image flags needed for a standard install.
+
+To use a different registry or override the tag:
 
 ```bash
-# Pin to a specific release
---set image.tag="v1.2.3"
-
 # Use a different registry
 --set image.repo="my-registry/canette"
+
+# Use the edge build (latest commit on main — development only)
+--set image.tag="edge"
 ```
+
+<Callout type="warn">
+  **Do not use `:edge` in production.** The `edge` tag is rebuilt on every commit to `main` and is not immutable — a pod restart can silently pull a newer image, leaving components running at mismatched versions. Stick with the chart's default versioned tag for any environment where stability matters.
+</Callout>
 
 `domain` is the base domain for all dynamic hostnames:
 - **App URLs**: `{app}-{project}.apps.example.com`
@@ -97,7 +103,7 @@ All service images default to `{image.repo}/{serviceName}:{image.tag}`.
 | Value | Default | Description |
 |-------|---------|-------------|
 | `image.repo` | `ghcr.io/canette/canette` | Base repository for all canette service images |
-| `image.tag` | `Chart.AppVersion` | Tag applied to all service images. Leave empty to track `appVersion` automatically. |
+| `image.tag` | `Chart.AppVersion` | Tag applied to all service images. Defaults to the chart's `appVersion` — versioned releases are tracked automatically. Set to `edge` to use the latest development build. |
 | `api.image` | derived | Override the API image |
 | `ui.image` | derived | Override the UI image |
 | `builder.image` | derived | Override the builder image |


### PR DESCRIPTION
Update `main` builds to create container images. These images are tagged `edge` as it's the latest build, minimal testing. Not for production use.