### PR TITLE
Fix build bug due to util canette-config missing in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ out/
 build/
 apps/docs/.docusaurus/
 apps/docs/build/
-canette-config
 apps/logstreamer/logstreamer
 apps/builder/git-init
 apps/builder/canette-build

--- a/apps/builder/cmd/canette-config/main.go
+++ b/apps/builder/cmd/canette-config/main.go
@@ -1,0 +1,38 @@
+// canette-config parses a canette.yaml and output a JSON object
+// representing the golang Struct. This is only for manuial debugging of canette.yaml files.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"canette.dev/builder/internal/config"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: canette-config <path-to-canette.yaml>")
+		os.Exit(1)
+	}
+	if err := run(os.Args[1], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "canette-config: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(path string, w io.Writer) error {
+	cfg, err := config.ParseFile(path)
+	if err != nil {
+		return err
+	}
+
+	result, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "Parsed object:\n%s\n", string(result))
+	return nil
+}


### PR DESCRIPTION
CI container image builds failing due to missing dependency for image `image-builder`.

Reason: Previous `.gitignore` entry to exclude build artifacts, matching folder name.

```
[linux/amd64 canette-bins 6/7] RUN CGO_ENABLED=0 GOOS=linux go build -o      
/canette-config ./cmd/canette-config/:                                                                                  
0.104 stat /src/cmd/canette-config: directory not found
```