### PR TITLE
Use native arm64 runners instead of QEMU for edge image builds

### DIFF
--- a/.github/workflows/build-edge.yml
+++ b/.github/workflows/build-edge.yml
@@ -21,13 +21,19 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            suffix: arm64
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -39,8 +45,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push edge images
+      - name: Build and push platform images
         env:
           IMAGE_REPO: ghcr.io/${{ github.repository_owner }}
-          TAG: edge
+          TAG: edge-${{ matrix.suffix }}
+          PLATFORMS: ${{ matrix.platform }}
         run: ./scripts/build-images.sh --push
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        env:
+          REPO: ghcr.io/${{ github.repository_owner }}
+        run: |
+          for image in canette-api canette-ui canette-builder canette-controller \
+                       canette-builder-git-init canette-builder-image-build canette-logstreamer; do
+            docker buildx imagetools create \
+              -t ${REPO}/${image}:edge \
+              ${REPO}/${image}:edge-amd64 \
+              ${REPO}/${image}:edge-arm64
+          done


### PR DESCRIPTION
## Summary

- Replaces QEMU emulation with a matrix of native runners: `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64)
- Both platform builds run in parallel, then a `merge` job stitches them into the final `:edge` multi-arch manifest using `docker buildx imagetools create`
- Removes `setup-qemu-action` — no longer needed

## Test plan

- [ ] Verify both matrix jobs (`amd64` and `arm64`) complete successfully
- [ ] Verify the `merge` job produces a valid multi-arch manifest (check with `docker buildx imagetools inspect ghcr.io/canette/canette-api:edge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)