### PR TITLE
Helm chart security hardening

### DIFF
--- a/apps/api/src/services/github-app-token.ts
+++ b/apps/api/src/services/github-app-token.ts
@@ -1,4 +1,17 @@
+import { readFileSync } from "node:fs"
 import { createSign } from "node:crypto"
+
+// readSecretOrEnv reads from a file if <KEY>_FILE is set, else falls back to
+// the plain env var. Supports Kubernetes file-mount (production) and env vars (local dev).
+function readSecretOrEnv(key: string): string | undefined {
+  const filePath = process.env[`${key}_FILE`]
+  if (filePath) {
+    try {
+      return readFileSync(filePath, "utf8").trimEnd()
+    } catch {}
+  }
+  return process.env[key]
+}
 
 // generateInstallationToken mints a GitHub App installation access token.
 // It reads GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY
@@ -8,7 +21,7 @@ import { createSign } from "node:crypto"
 export async function generateInstallationToken(): Promise<string> {
   const appId = process.env.GITHUB_APP_ID
   const installationId = process.env.GITHUB_APP_INSTALLATION_ID
-  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY
+  const privateKey = readSecretOrEnv("GITHUB_APP_PRIVATE_KEY")
 
   if (!appId || !installationId || !privateKey) {
     throw new Error("GitHub App not configured (missing GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, or GITHUB_APP_PRIVATE_KEY)")

--- a/apps/api/src/utils/crypto.ts
+++ b/apps/api/src/utils/crypto.ts
@@ -4,10 +4,23 @@
 // ENCRYPTION_KEY must be a 64-char hex string (32 bytes) in the environment.
 // The process throws at module load if the key is missing or malformed.
 
+import { readFileSync } from "node:fs"
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto"
 
+// readSecretOrEnv reads from a file if <KEY>_FILE is set, else falls back to
+// the plain env var. Supports Kubernetes file-mount (production) and env vars (local dev).
+function readSecretOrEnv(key: string): string | undefined {
+  const filePath = process.env[`${key}_FILE`]
+  if (filePath) {
+    try {
+      return readFileSync(filePath, "utf8").trimEnd()
+    } catch {}
+  }
+  return process.env[key]
+}
+
 function getMasterKey(): Buffer {
-  const hex = process.env.ENCRYPTION_KEY
+  const hex = readSecretOrEnv("ENCRYPTION_KEY")
   if (!hex || hex.length !== 64 || !/^[0-9a-f]+$/i.test(hex)) {
     throw new Error(
       "ENCRYPTION_KEY must be a 64-character hex string. " +

--- a/apps/builder/internal/githubapp/token.go
+++ b/apps/builder/internal/githubapp/token.go
@@ -27,7 +27,7 @@ import (
 func GenerateInstallationToken(ctx context.Context) (string, error) {
 	appID := os.Getenv("GITHUB_APP_ID")
 	installID := os.Getenv("GITHUB_APP_INSTALLATION_ID")
-	privateKeyPEM := os.Getenv("GITHUB_APP_PRIVATE_KEY")
+	privateKeyPEM := readSecretOrEnv("GITHUB_APP_PRIVATE_KEY")
 
 	var missing []string
 	if appID == "" {
@@ -138,4 +138,15 @@ func parsePrivateKey(pemStr string) (*rsa.PrivateKey, error) {
 
 func base64URLEncode(data []byte) string {
 	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// readSecretOrEnv reads a secret value from a file if <KEY>_FILE is set,
+// falling back to the plain environment variable.
+func readSecretOrEnv(key string) string {
+	if path := os.Getenv(key + "_FILE"); path != "" {
+		if data, err := os.ReadFile(path); err == nil {
+			return strings.TrimRight(string(data), "\n")
+		}
+	}
+	return os.Getenv(key)
 }

--- a/apps/builder/main.go
+++ b/apps/builder/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -120,6 +122,8 @@ func run(log *zap.Logger) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	startHealthServer(ctx, log, envOr("HEALTH_ADDR", ":8081"))
+
 	b := builder.New(
 		store.New(db, log),
 		k8sClient,
@@ -130,6 +134,29 @@ func run(log *zap.Logger) error {
 		maxConcurrent,
 	)
 	return b.Run(ctx)
+}
+
+func startHealthServer(ctx context.Context, log *zap.Logger, addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("health server error", zap.Error(err))
+		}
+	}()
 }
 
 func buildK8sClient() (kubernetes.Interface, error) {
@@ -151,11 +178,23 @@ func buildK8sClient() (kubernetes.Interface, error) {
 }
 
 func requireEnv(key string) (string, error) {
-	v := os.Getenv(key)
+	v := readSecretOrEnv(key)
 	if v == "" {
 		return "", fmt.Errorf("required environment variable %s is not set", key)
 	}
 	return v, nil
+}
+
+// readSecretOrEnv reads a secret value from a file if <KEY>_FILE is set,
+// falling back to the plain environment variable. This supports both the
+// Kubernetes file-mount pattern (production) and plain env vars (local dev).
+func readSecretOrEnv(key string) string {
+	if path := os.Getenv(key + "_FILE"); path != "" {
+		if data, err := os.ReadFile(path); err == nil {
+			return strings.TrimRight(string(data), "\n")
+		}
+	}
+	return os.Getenv(key)
 }
 
 func envOr(key, fallback string) string {

--- a/apps/controller/main.go
+++ b/apps/controller/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -121,8 +123,32 @@ func run(log *zap.Logger) error {
 	}
 
 	// ── Run ───────────────────────────────────────────────────────────────────
+	startHealthServer(ctx, log, envOr("HEALTH_ADDR", ":8082"))
 	ctrl := controller.New(s, k8sClient, dynClient, cfg, cryptoKey, log)
 	return ctrl.Run(ctx)
+}
+
+func startHealthServer(ctx context.Context, log *zap.Logger, addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("health server error", zap.Error(err))
+		}
+	}()
 }
 
 func loadKubeConfig() (*rest.Config, error) {
@@ -135,11 +161,23 @@ func loadKubeConfig() (*rest.Config, error) {
 }
 
 func requireEnv(key string) (string, error) {
-	v := os.Getenv(key)
+	v := readSecretOrEnv(key)
 	if v == "" {
 		return "", fmt.Errorf("%s environment variable is required", key)
 	}
 	return v, nil
+}
+
+// readSecretOrEnv reads a secret value from a file if <KEY>_FILE is set,
+// falling back to the plain environment variable. This supports both the
+// Kubernetes file-mount pattern (production) and plain env vars (local dev).
+func readSecretOrEnv(key string) string {
+	if path := os.Getenv(key + "_FILE"); path != "" {
+		if data, err := os.ReadFile(path); err == nil {
+			return strings.TrimRight(string(data), "\n")
+		}
+	}
+	return os.Getenv(key)
 }
 
 func envOr(key, def string) string {

--- a/charts/canette/templates/api/deployment.yaml
+++ b/charts/canette/templates/api/deployment.yaml
@@ -16,11 +16,18 @@ spec:
       labels:
         app.kubernetes.io/name: canette-api
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: api
           {{- $image := include "canette.serviceImage" (list . "canette-api" .Values.api.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: 3001
           env:
@@ -42,11 +49,8 @@ spec:
               {{- else }}
               value: {{ include "canette.databaseURL" . | quote }}
               {{- end }}
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: canette-encryption-key
-                  key: key
+            - name: ENCRYPTION_KEY_FILE
+              value: /run/secrets/encryption-key
             - name: BETTER_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
@@ -97,16 +101,8 @@ spec:
                 secretKeyRef:
                   name: canette-api-secrets
                   key: github-app-installation-id
-            - name: GITHUB_APP_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  {{- if ((.Values.api.githubApp.privateKeySecretRef).name) }}
-                  name: {{ .Values.api.githubApp.privateKeySecretRef.name }}
-                  key: {{ .Values.api.githubApp.privateKeySecretRef.key }}
-                  {{- else }}
-                  name: canette-api-secrets
-                  key: github-app-private-key
-                  {{- end }}
+            - name: GITHUB_APP_PRIVATE_KEY_FILE
+              value: /run/secrets/github-app-private-key
             {{- end }}
             - name: UI_URL
               value: {{ include "canette.uiURL" . | quote }}
@@ -141,5 +137,38 @@ spec:
               port: 3001
             initialDelaySeconds: 5
             periodSeconds: 10
+          volumeMounts:
+            - name: encryption-key
+              mountPath: /run/secrets/encryption-key
+              subPath: key
+              readOnly: true
+            {{- if .Values.api.githubApp.appId }}
+            - name: github-app-private-key
+              mountPath: /run/secrets/github-app-private-key
+              subPath: key
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+      volumes:
+        - name: encryption-key
+          secret:
+            secretName: canette-encryption-key
+            items:
+              - key: key
+                path: key
+        {{- if .Values.api.githubApp.appId }}
+        - name: github-app-private-key
+          secret:
+            {{- if ((.Values.api.githubApp.privateKeySecretRef).name) }}
+            secretName: {{ .Values.api.githubApp.privateKeySecretRef.name }}
+            items:
+              - key: {{ .Values.api.githubApp.privateKeySecretRef.key }}
+                path: key
+            {{- else }}
+            secretName: canette-api-secrets
+            items:
+              - key: github-app-private-key
+                path: key
+            {{- end }}
+        {{- end }}

--- a/charts/canette/templates/api/networkpolicy.yaml
+++ b/charts/canette/templates/api/networkpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: canette-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: canette-api
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: canette-api
+  policyTypes:
+    - Ingress
+  ingress:
+    # UI server-side fetches (Next.js server components call the API in-cluster)
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-ui
+      ports:
+        - protocol: TCP
+          port: 3001
+    # Gateway/ingress-controller (webhooks and any direct external API access)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.controller.gateway.namespace }}
+      ports:
+        - protocol: TCP
+          port: 3001

--- a/charts/canette/templates/builder/deployment.yaml
+++ b/charts/canette/templates/builder/deployment.yaml
@@ -22,12 +22,16 @@ spec:
           {{- $image := include "canette.serviceImage" (list . "canette-builder" .Values.builder.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           env:
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: canette-encryption-key
-                  key: key
+            - name: ENCRYPTION_KEY_FILE
+              value: /run/secrets/encryption-key
             {{- if and (not .Values.postgres.enabled) .Values.externalDatabase.passwordSecretRef.name }}
             - name: DB_PASSWORD
               valueFrom:
@@ -75,16 +79,56 @@ spec:
                 secretKeyRef:
                   name: canette-api-secrets
                   key: github-app-installation-id
-            - name: GITHUB_APP_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  {{- if ((.Values.api.githubApp.privateKeySecretRef).name) }}
-                  name: {{ .Values.api.githubApp.privateKeySecretRef.name }}
-                  key: {{ .Values.api.githubApp.privateKeySecretRef.key }}
-                  {{- else }}
-                  name: canette-api-secrets
-                  key: github-app-private-key
-                  {{- end }}
+            - name: GITHUB_APP_PRIVATE_KEY_FILE
+              value: /run/secrets/github-app-private-key
+            {{- end }}
+          ports:
+            - containerPort: 8081
+              name: health
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: encryption-key
+              mountPath: /run/secrets/encryption-key
+              subPath: key
+              readOnly: true
+            {{- if .Values.api.githubApp.appId }}
+            - name: github-app-private-key
+              mountPath: /run/secrets/github-app-private-key
+              subPath: key
+              readOnly: true
             {{- end }}
           resources:
             {{- toYaml .Values.builder.resources | nindent 12 }}
+      volumes:
+        - name: encryption-key
+          secret:
+            secretName: canette-encryption-key
+            items:
+              - key: key
+                path: key
+        {{- if .Values.api.githubApp.appId }}
+        - name: github-app-private-key
+          secret:
+            {{- if ((.Values.api.githubApp.privateKeySecretRef).name) }}
+            secretName: {{ .Values.api.githubApp.privateKeySecretRef.name }}
+            items:
+              - key: {{ .Values.api.githubApp.privateKeySecretRef.key }}
+                path: key
+            {{- else }}
+            secretName: canette-api-secrets
+            items:
+              - key: github-app-private-key
+                path: key
+            {{- end }}
+        {{- end }}

--- a/charts/canette/templates/buildkit/deployment.yaml
+++ b/charts/canette/templates/buildkit/deployment.yaml
@@ -21,6 +21,7 @@ spec:
           type: Unconfined
         appArmorProfile:
           type: Unconfined
+        fsGroup: 1000
       containers:
         - name: buildkitd
           image: {{ .Values.buildkit.image }}
@@ -34,6 +35,8 @@ spec:
           ports:
             - containerPort: 1234
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
             seccompProfile:
               type: Unconfined
           volumeMounts:

--- a/charts/canette/templates/buildkit/networkpolicy.yaml
+++ b/charts/canette/templates/buildkit/networkpolicy.yaml
@@ -1,0 +1,68 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: buildkitd
+  namespace: {{ include "canette.buildNamespace" . }}
+  labels:
+    app.kubernetes.io/name: buildkitd
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: buildkitd
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Build job pods (canette-build binary) connect to submit builds.
+    # The builder service pod does not talk to buildkitd — it only creates Jobs and tails logs via the K8s API.
+    - from:
+        - podSelector:
+            matchLabels:
+              canette.dev/component: builder
+      ports:
+        - protocol: TCP
+          port: 1234
+  egress:
+    {{- if .Values.buildkit.restrictEgress }}
+    # DNS — kube-dns must be reachable for all image and package registry lookups
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.registry.enabled }}
+    # In-cluster registry — buildkitd pushes built images here after each build
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: registry
+      ports:
+        - protocol: TCP
+          port: 5000
+    {{- end }}
+    # Internet egress for base image pulls and package fetches (npm, PyPI, apt, etc.)
+    # RFC-1918 ranges are blocked to prevent builds from reaching cluster-internal services.
+    # Set buildkit.restrictEgress=false if builds need to reach private mirrors in RFC-1918 space.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 100.64.0.0/10
+    {{- else }}
+    # Unrestricted egress — buildkit.restrictEgress is false
+    - {}
+    {{- end }}

--- a/charts/canette/templates/controller/deployment.yaml
+++ b/charts/canette/templates/controller/deployment.yaml
@@ -22,12 +22,16 @@ spec:
           {{- $image := include "canette.serviceImage" (list . "canette-controller" .Values.controller.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           env:
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: canette-encryption-key
-                  key: key
+            - name: ENCRYPTION_KEY_FILE
+              value: /run/secrets/encryption-key
             {{- if and (not .Values.postgres.enabled) .Values.externalDatabase.passwordSecretRef.name }}
             - name: DB_PASSWORD
               valueFrom:
@@ -60,5 +64,32 @@ spec:
               value: {{ .Values.controller.logTailInterval | quote }}
             - name: MAX_CONCURRENT
               value: {{ .Values.controller.maxConcurrent | quote }}
+          ports:
+            - containerPort: 8082
+              name: health
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: encryption-key
+              mountPath: /run/secrets/encryption-key
+              subPath: key
+              readOnly: true
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
+      volumes:
+        - name: encryption-key
+          secret:
+            secretName: canette-encryption-key
+            items:
+              - key: key
+                path: key

--- a/charts/canette/templates/logstreamer/deployment.yaml
+++ b/charts/canette/templates/logstreamer/deployment.yaml
@@ -22,6 +22,13 @@ spec:
           {{- $image := include "canette.serviceImage" (list . "canette-logstreamer" .Values.logstreamer.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: 8080
           env:

--- a/charts/canette/templates/logstreamer/networkpolicy.yaml
+++ b/charts/canette/templates/logstreamer/networkpolicy.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: canette-logstreamer
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     - from:
         - podSelector:
@@ -19,3 +20,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+  egress:
+    # K8s API server — required to list pods and stream logs across app namespaces
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/charts/canette/templates/migrations/job.yaml
+++ b/charts/canette/templates/migrations/job.yaml
@@ -38,6 +38,12 @@ spec:
           {{- $image := include "canette.serviceImage" (list . "canette-api" .Values.api.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command: ["./db-migrate"]
           env:
             {{- if and (not .Values.postgres.enabled) .Values.externalDatabase.passwordSecretRef.name }}

--- a/charts/canette/templates/postgres/deployment.yaml
+++ b/charts/canette/templates/postgres/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/name: postgres
     spec:
       priorityClassName: canette-postgres-critical
+      securityContext:
+        fsGroup: 999
       containers:
         - name: postgres
           image: {{ .Values.postgres.image }}
@@ -29,7 +31,7 @@ spec:
                 name: postgres-credentials
           volumeMounts:
             - name: data
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
           readinessProbe:

--- a/charts/canette/templates/postgres/networkpolicy.yaml
+++ b/charts/canette/templates/postgres/networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: postgres
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-api
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-controller
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-builder
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-migrations
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}

--- a/charts/canette/templates/postgres/poddisruptionbudget.yaml
+++ b/charts/canette/templates/postgres/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: postgres
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+{{- end }}

--- a/charts/canette/templates/registry/auth-secret.yaml
+++ b/charts/canette/templates/registry/auth-secret.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: {{ include "canette.buildNamespace" . }}
   labels:
     {{- include "canette.labels" . | nindent 4 }}
-type: Opaque
+type: kubernetes.io/dockerconfigjson
 stringData:
   .dockerconfigjson: {{ $dockerconfig | quote }}
 {{- else if .Values.externalRegistry.username }}
@@ -72,7 +72,7 @@ metadata:
   namespace: {{ include "canette.buildNamespace" . }}
   labels:
     {{- include "canette.labels" . | nindent 4 }}
-type: Opaque
+type: kubernetes.io/dockerconfigjson
 stringData:
   .dockerconfigjson: {{ $dockerconfig | quote }}
 {{- end }}

--- a/charts/canette/templates/registry/deployment.yaml
+++ b/charts/canette/templates/registry/deployment.yaml
@@ -18,10 +18,16 @@ spec:
         app.kubernetes.io/name: registry
     spec:
       priorityClassName: canette-registry-critical
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: registry
           image: {{ .Values.registry.image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" .Values.registry.image }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: 5000
           env:

--- a/charts/canette/templates/registry/networkpolicy.yaml
+++ b/charts/canette/templates/registry/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.registry.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: registry
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: registry
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: registry
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # API pod (image listing / deletion)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-api
+        # Builder service pod (registry auth secret management)
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: canette-builder
+        # BuildKit daemon (image push after build)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "canette.buildNamespace" . }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: buildkitd
+        # Gateway/ingress-controller (external registry access via HTTPRoute)
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.controller.gateway.namespace }}
+      ports:
+        - protocol: TCP
+          port: 5000
+{{- end }}

--- a/charts/canette/templates/registry/poddisruptionbudget.yaml
+++ b/charts/canette/templates/registry/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.registry.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: registry
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: registry
+    {{- include "canette.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: registry
+{{- end }}

--- a/charts/canette/templates/ui/deployment.yaml
+++ b/charts/canette/templates/ui/deployment.yaml
@@ -16,11 +16,18 @@ spec:
       labels:
         app.kubernetes.io/name: canette-ui
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: ui
           {{- $image := include "canette.serviceImage" (list . "canette-ui" .Values.ui.image) }}
           image: {{ $image }}
           imagePullPolicy: {{ include "canette.imagePullPolicy" $image }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: 3000
           env:

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -30,7 +30,7 @@ encryptionKey: ""
 # ---------------------------------------------------------------------------
 postgres:
   enabled: true
-  image: postgres:18-alpine
+  image: postgres:18.3-alpine3.23
   # Override auto-generated postgres password.
   # By default canette generates a random password on first install and stores it in
   # the postgres-credentials Secret, reusing it on every upgrade.
@@ -80,7 +80,7 @@ externalRegistry:
 # ---------------------------------------------------------------------------
 registry:
   enabled: true
-  image: registry:2
+  image: registry:2.8.3
   # Override auto-generated registry credentials.
   # By default canette generates a random username/password on first install and stores
   # them in the canette-registry-credentials Secret, reusing them on every upgrade.
@@ -118,6 +118,12 @@ buildkit:
   # The in-cluster registry is added automatically when registry.enabled=true.
   # Format: "<host:port>": { http: true, insecure: true }
   registries: {}
+  # Restrict buildkit egress to internet-only by blocking RFC-1918 ranges.
+  # This prevents a compromised build from reaching cluster-internal services
+  # while still allowing package fetches from npm, PyPI, Docker Hub, etc.
+  # Set to false if builds need to reach private package mirrors or registries
+  # in RFC-1918 address space (e.g. an internal Artifactory or Nexus instance).
+  restrictEgress: true
 
 # ---------------------------------------------------------------------------
 # Builder service


### PR DESCRIPTION
Addresses the findings from the security audit in #17.

Fixes #17

## What changed

**NetworkPolicies** — added default-deny ingress policies for all services with explicit allow rules:
- `postgres` — api, controller, builder, migrations only
- `registry` — api, builder, buildkitd, and gateway namespace
- `buildkit` — build job pods only (builder service pod does not connect to buildkitd)
- `api` — UI pod and gateway namespace
- `logstreamer` — added egress to K8s API (443/6443)

**Container security contexts** — baseline hardening across all deployments and the migrations job:
- `runAsNonRoot`, `runAsUser`, `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`
- Postgres and buildkitd are exceptions: postgres image requires root for startup (gosu-based privilege drop); buildkitd rootless mode requires setuid access for `newuidmap`/`newgidmap`

**Secrets as files** — `ENCRYPTION_KEY` and `GITHUB_APP_PRIVATE_KEY` are now mounted as files under `/run/secrets/` instead of passed as env vars. Updated in api (TypeScript), builder (Go), and controller (Go) with env var fallback for local dev.

**automountServiceAccountToken** — explicitly disabled on api and ui pods.

**Health probes** — added liveness and readiness probes to controller (`:8082`) and builder (`:8081`), including the health server goroutine in both services.

**Image tags pinned** — `postgres:18-alpine` → `postgres:18.3-alpine3.23`, `registry:2` → `registry:2.8.3`.

**Registry secret type** — changed from `Opaque` to `kubernetes.io/dockerconfigjson`.

**PodDisruptionBudgets** — added `minAvailable: 1` for postgres and registry.

**fsGroup** — set on postgres (999), registry (1000), and buildkit (1000) pods.

**BuildKit egress** — added `buildkit.restrictEgress` value (default `true`) controlling whether egress is limited to DNS, the in-cluster registry, and internet-minus-RFC-1918, or left unrestricted.

## Deferred / accepted as-is

- Postgres TLS (M2): bundled postgres is evaluation-only, not production
- Logstreamer ClusterRole (H2): application-level restriction to `can-*` namespaces accepted as sufficient
- BuildKit seccomp/AppArmor (C1): `Unconfined` is required for rootless BuildKit daemon; `RuntimeDefault` applies to build job pods (already set in `jobs.go`)
- `readOnlyRootFilesystem` for api/ui: deferred pending investigation of Bun/Next.js tmpfs needs