### PR TITLE
Add dependabot.yml

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5      


### PR DESCRIPTION
Starting light with just actions and root bun.Added basic dependabot file for non security-updates. Starting light with jjst bun and github actions until we see how well it works. An alternative would be renovate bot, but hopefully this works just as well.