### PR TITLE
chore: add dependabot update groups to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5      
+      default-days: 5
+    groups:
+      fumadocs:
+        patterns:
+          - "fumadocs-*"
+          - "lucide-react"
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "gomod"
     directories:
       - "/apps/controller"
@@ -15,9 +25,24 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 5
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5      
+      default-days: 5
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Configures dependabot grouping so coupled packages always move together and minor/patch updates are batched instead of generating one PR per package.

- **bun**: `fumadocs-*` + `lucide-react` in one group (type compatibility coupling — bumping lucide-react alone breaks fumadocs-ui's `LoaderOutput` types); all other minor/patch updates in a catch-all group
- **gomod**: `k8s.io/*` + `sigs.k8s.io/*` in one group per app (structured-merge-diff v4/v6 coupling — bumping apimachinery alone breaks client-go); all other minor/patch in a catch-all group
- **github-actions**: minor/patch catch-all group

**Expected PR reduction:** bun 4→1-2, gomod 9→3, github-actions bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)