### PR TITLE
Teams credentials UI polish and GitHub App link across multiple teams

### DIFF
--- a/apps/api/migrations/000003_git_credentials_connected_by.down.sql
+++ b/apps/api/migrations/000003_git_credentials_connected_by.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE git_credentials DROP COLUMN connected_by_user_id;

--- a/apps/api/migrations/000003_git_credentials_connected_by.up.sql
+++ b/apps/api/migrations/000003_git_credentials_connected_by.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE git_credentials ADD COLUMN connected_by_user_id TEXT REFERENCES "user"(id) ON DELETE SET NULL;

--- a/apps/api/src/db/types.ts
+++ b/apps/api/src/db/types.ts
@@ -90,6 +90,7 @@ export interface Database {
     encrypted_value: string
     ssh_known_hosts: string | null
     installation_id: string | null  // only set for github_app type (per-team installations)
+    connected_by_user_id: string | null  // user who connected this GitHub App installation
     created_at: string
   }
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,7 +7,12 @@ import { createApp } from "./app"
 if (process.env.RUN_MIGRATIONS !== "false") {
   const migrationsDir = process.env.MIGRATIONS_DIR
     ?? resolve(process.cwd(), "migrations")
-  await runMigrations(db, migrationsDir)
+  try {
+    await runMigrations(db, migrationsDir)
+  } catch (err) {
+    console.error("Migration failed, refusing to start:", err)
+    process.exit(1)
+  }
 }
 
 initSystemCredentials(db).catch((err) => {

--- a/apps/api/src/routes/github-app.ts
+++ b/apps/api/src/routes/github-app.ts
@@ -2,7 +2,8 @@ import { Hono } from "hono"
 import { db } from "../db/db"
 import { requireAuth } from "../middleware/require-auth"
 import type { AppEnv } from "../types"
-import { upsertGithubAppInstallation, isTeamMember, listLinkableInstallations, linkInstallationToTeam } from "../services/git-credentials"
+import { upsertGithubAppInstallation, listLinkableInstallations, linkInstallationToTeam } from "../services/git-credentials"
+import { isTeamMember } from "../services/membership"
 import { ServiceError } from "../services/errors"
 import { getInstallationDetails } from "../services/github-app-token"
 import { createStateToken, verifyStateToken } from "../utils/github-app-state"
@@ -102,13 +103,13 @@ githubAppRouter.get("/linkable", requireAuth, async (c) => {
 // Links an installation the caller personally connected to an additional team they belong to.
 githubAppRouter.post("/link", requireAuth, async (c) => {
   const body = await c.req.json().catch(() => ({}))
-  const { teamId, credentialId } = body as { teamId?: string; credentialId?: string }
-  if (!teamId || !credentialId) {
-    return c.json({ error: "teamId and credentialId are required", code: "VALIDATION_ERROR" }, 400)
+  const { teamId, installationId } = body as { teamId?: string; installationId?: string }
+  if (!teamId || !installationId) {
+    return c.json({ error: "teamId and installationId are required", code: "VALIDATION_ERROR" }, 400)
   }
   const session = c.get("session")
   try {
-    const cred = await linkInstallationToTeam(db, teamId, session.user.id, credentialId)
+    const cred = await linkInstallationToTeam(db, teamId, session.user.id, installationId)
     return c.json(cred, 201)
   } catch (err) {
     if (err instanceof ServiceError) return c.json({ error: err.message, code: err.code }, err.status as 400 | 403 | 404 | 409 | 422)

--- a/apps/api/src/routes/github-app.ts
+++ b/apps/api/src/routes/github-app.ts
@@ -2,7 +2,8 @@ import { Hono } from "hono"
 import { db } from "../db/db"
 import { requireAuth } from "../middleware/require-auth"
 import type { AppEnv } from "../types"
-import { upsertGithubAppInstallation, isTeamMember } from "../services/git-credentials"
+import { upsertGithubAppInstallation, isTeamMember, listLinkableInstallations, linkInstallationToTeam } from "../services/git-credentials"
+import { ServiceError } from "../services/errors"
 import { getInstallationDetails } from "../services/github-app-token"
 import { createStateToken, verifyStateToken } from "../utils/github-app-state"
 
@@ -75,11 +76,42 @@ githubAppRouter.get("/callback", async (c) => {
     const details = await getInstallationDetails(installationId)
     const accountLogin = details?.account?.login ?? installationId
 
-    await upsertGithubAppInstallation(db, teamId, installationId, accountLogin)
+    await upsertGithubAppInstallation(db, teamId, installationId, accountLogin, claims.userId)
   } catch (err) {
     console.error("GitHub App callback error", err)
     return c.redirect(`${uiBase}/dashboard/teams/${teamId}?tab=credentials&error=github-app-callback-failed`)
   }
 
   return c.redirect(`${uiBase}/dashboard/teams/${teamId}?tab=credentials&github_app=installed`)
+})
+
+// GET /api/v1/github-app/linkable?teamId=:teamId
+// Returns GitHub App installations the current user personally connected on other teams,
+// excluding any already linked to teamId.
+githubAppRouter.get("/linkable", requireAuth, async (c) => {
+  const teamId = c.req.query("teamId")
+  if (!teamId) {
+    return c.json({ error: "teamId is required", code: "VALIDATION_ERROR" }, 400)
+  }
+  const session = c.get("session")
+  const installations = await listLinkableInstallations(db, teamId, session.user.id)
+  return c.json({ installations })
+})
+
+// POST /api/v1/github-app/link
+// Links an installation the caller personally connected to an additional team they belong to.
+githubAppRouter.post("/link", requireAuth, async (c) => {
+  const body = await c.req.json().catch(() => ({}))
+  const { teamId, credentialId } = body as { teamId?: string; credentialId?: string }
+  if (!teamId || !credentialId) {
+    return c.json({ error: "teamId and credentialId are required", code: "VALIDATION_ERROR" }, 400)
+  }
+  const session = c.get("session")
+  try {
+    const cred = await linkInstallationToTeam(db, teamId, session.user.id, credentialId)
+    return c.json(cred, 201)
+  } catch (err) {
+    if (err instanceof ServiceError) return c.json({ error: err.message, code: err.code }, err.status as 400 | 403 | 404 | 409 | 422)
+    throw err
+  }
 })

--- a/apps/api/src/services/git-credentials.ts
+++ b/apps/api/src/services/git-credentials.ts
@@ -17,6 +17,7 @@ function mapCredential(row: GitCredentialRow): GitCredential {
     provider: row.provider as GitProvider,
     type: row.type as GitCredentialType,
     ...(row.installation_id ? { installationId: row.installation_id } : {}),
+    ...(row.connected_by_user_id ? { connectedByUserId: row.connected_by_user_id } : {}),
     createdAt: row.created_at,
     // encrypted_value intentionally omitted
   }
@@ -173,14 +174,16 @@ export async function createCredential(
 }
 
 // upsertGithubAppInstallation creates or updates a team-owned GitHub App credential
-// identified by its installation_id. Called from the GitHub App callback.
+// identified by its installation_id. Called from the GitHub App callback and link flow.
+// userId is stored as connected_by_user_id on insert (not on update — ownership is immutable).
 export async function upsertGithubAppInstallation(
   db: DB,
   teamId: string,
   installationId: string,
   accountLogin: string,
+  userId: string,
 ): Promise<GitCredential> {
-  const name = `${accountLogin} (GitHub App)`
+  const name = accountLogin
   const now = new Date().toISOString()
 
   // Check if a credential with this installation_id already exists for this team.
@@ -192,7 +195,7 @@ export async function upsertGithubAppInstallation(
     .executeTakeFirst()
 
   if (existing) {
-    // Update the name in case the account was renamed.
+    // Update the name in case the account was renamed. Never overwrite connected_by_user_id.
     await db
       .updateTable("git_credentials")
       .set({ name })
@@ -218,6 +221,7 @@ export async function upsertGithubAppInstallation(
       encrypted_value: encrypt(""),
       ssh_known_hosts: null,
       installation_id: installationId,
+      connected_by_user_id: userId,
       created_at: now,
     })
     .execute()
@@ -227,6 +231,81 @@ export async function upsertGithubAppInstallation(
     .where("id", "=", id)
     .executeTakeFirstOrThrow()
   return mapCredential(row)
+}
+
+// listLinkableInstallations returns GitHub App installations the caller personally connected
+// on other teams, that are not yet linked to targetTeamId.
+// Only installations where connected_by_user_id = userId are returned — never someone else's.
+export async function listLinkableInstallations(
+  db: DB,
+  teamId: string,
+  userId: string,
+): Promise<{ id: string; name: string }[]> {
+  const member = await isTeamMember(db, teamId, userId)
+  if (!member) return []
+
+  // installation_ids already linked to the target team
+  const alreadyLinked = await db
+    .selectFrom("git_credentials")
+    .select("installation_id")
+    .where("team_id", "=", teamId)
+    .where("type", "=", "github_app")
+    .where("installation_id", "is not", null)
+    .execute()
+  const linkedIds = alreadyLinked.map((r) => r.installation_id as string)
+
+  let query = db
+    .selectFrom("git_credentials")
+    .select(["id", "installation_id", "name"])
+    .where("type", "=", "github_app")
+    .where("team_id", "is not", null)
+    .where("team_id", "!=", teamId)
+    .where("connected_by_user_id", "=", userId)
+    .where("installation_id", "is not", null)
+
+  if (linkedIds.length > 0) {
+    query = query.where("installation_id", "not in", linkedIds)
+  }
+
+  const rows = await query.execute()
+
+  // Deduplicate by installation_id (same install linked to multiple teams by same user)
+  const seen = new Set<string>()
+  const result: { id: string; name: string }[] = []
+  for (const row of rows) {
+    if (!seen.has(row.installation_id!)) {
+      seen.add(row.installation_id!)
+      result.push({ id: row.id, name: row.name })
+    }
+  }
+  return result
+}
+
+// linkInstallationToTeam links a GitHub App installation the caller personally connected
+// to an additional team they belong to. Accepts the credential id (not the raw GitHub
+// installationId) — the installationId is fetched from the DB to prevent client tampering.
+export async function linkInstallationToTeam(
+  db: DB,
+  teamId: string,
+  userId: string,
+  credentialId: string,
+): Promise<GitCredential> {
+  const member = await isTeamMember(db, teamId, userId)
+  if (!member) throw new ServiceError("Not found", "NOT_FOUND", 404)
+
+  // Security boundary: only the user who connected the installation can link it.
+  // The installationId is never taken from the client — it is read from the DB here.
+  const source = await db
+    .selectFrom("git_credentials")
+    .select(["installation_id", "name"])
+    .where("id", "=", credentialId)
+    .where("type", "=", "github_app")
+    .where("connected_by_user_id", "=", userId)
+    .executeTakeFirst()
+
+  if (!source?.installation_id) throw new ServiceError("Not found", "NOT_FOUND", 404)
+
+  return upsertGithubAppInstallation(db, teamId, source.installation_id, source.name, userId)
 }
 
 export async function updateCredential(

--- a/apps/api/src/services/git-credentials.ts
+++ b/apps/api/src/services/git-credentials.ts
@@ -4,6 +4,7 @@ import type { Selectable } from "kysely"
 import type { Database } from "../db/types"
 import { encrypt } from "../utils/crypto"
 import { ServiceError } from "./errors"
+import { isTeamMember } from "./membership"
 
 // ── Internal row type ─────────────────────────────────────────────────────────
 
@@ -47,6 +48,7 @@ export async function initSystemCredentials(db: DB): Promise<void> {
         encrypted_value: encrypt(""),
         ssh_known_hosts: null,
         installation_id: null,
+        connected_by_user_id: null,
         created_at: now,
       })
       .onConflict((oc) => oc.column("id").doNothing())
@@ -57,19 +59,6 @@ export async function initSystemCredentials(db: DB): Promise<void> {
       .where("id", "=", GITHUB_APP_CREDENTIAL_ID)
       .execute()
   }
-}
-
-// ── Access helpers ────────────────────────────────────────────────────────────
-
-// Returns true if userId is a member of the given team.
-export async function isTeamMember(db: DB, teamId: string, userId: string): Promise<boolean> {
-  const row = await db
-    .selectFrom("team_members")
-    .select("id")
-    .where("team_id", "=", teamId)
-    .where("user_id", "=", userId)
-    .executeTakeFirst()
-  return !!row
 }
 
 // ── Service functions ─────────────────────────────────────────────────────────
@@ -240,72 +229,52 @@ export async function listLinkableInstallations(
   db: DB,
   teamId: string,
   userId: string,
-): Promise<{ id: string; name: string }[]> {
+): Promise<{ installationId: string; name: string }[]> {
   const member = await isTeamMember(db, teamId, userId)
   if (!member) return []
 
-  // installation_ids already linked to the target team
-  const alreadyLinked = await db
+  const alreadyLinkedSubquery = db
     .selectFrom("git_credentials")
     .select("installation_id")
     .where("team_id", "=", teamId)
     .where("type", "=", "github_app")
     .where("installation_id", "is not", null)
-    .execute()
-  const linkedIds = alreadyLinked.map((r) => r.installation_id as string)
 
-  let query = db
+  const rows = await db
     .selectFrom("git_credentials")
-    .select(["id", "installation_id", "name"])
+    .distinct()
+    .select(["installation_id", "name"])
     .where("type", "=", "github_app")
-    .where("team_id", "is not", null)
-    .where("team_id", "!=", teamId)
     .where("connected_by_user_id", "=", userId)
-    .where("installation_id", "is not", null)
-
-  if (linkedIds.length > 0) {
-    query = query.where("installation_id", "not in", linkedIds)
-  }
-
-  const rows = await query.execute()
-
-  // Deduplicate by installation_id (same install linked to multiple teams by same user)
-  const seen = new Set<string>()
-  const result: { id: string; name: string }[] = []
-  for (const row of rows) {
-    if (!seen.has(row.installation_id!)) {
-      seen.add(row.installation_id!)
-      result.push({ id: row.id, name: row.name })
-    }
-  }
-  return result
+    .where("installation_id", "not in", alreadyLinkedSubquery)
+    .execute()
+  return rows.map((r) => ({ installationId: r.installation_id!, name: r.name }))
 }
 
 // linkInstallationToTeam links a GitHub App installation the caller personally connected
-// to an additional team they belong to. Accepts the credential id (not the raw GitHub
-// installationId) — the installationId is fetched from the DB to prevent client tampering.
+// to an additional team they belong to. Ownership is enforced by requiring
+// connected_by_user_id = userId — rejects if the installation was connected by someone else.
 export async function linkInstallationToTeam(
   db: DB,
   teamId: string,
   userId: string,
-  credentialId: string,
+  installationId: string,
 ): Promise<GitCredential> {
   const member = await isTeamMember(db, teamId, userId)
   if (!member) throw new ServiceError("Not found", "NOT_FOUND", 404)
 
   // Security boundary: only the user who connected the installation can link it.
-  // The installationId is never taken from the client — it is read from the DB here.
   const source = await db
     .selectFrom("git_credentials")
     .select(["installation_id", "name"])
-    .where("id", "=", credentialId)
+    .where("installation_id", "=", installationId)
     .where("type", "=", "github_app")
     .where("connected_by_user_id", "=", userId)
     .executeTakeFirst()
 
-  if (!source?.installation_id) throw new ServiceError("Not found", "NOT_FOUND", 404)
+  if (!source) throw new ServiceError("Not found", "NOT_FOUND", 404)
 
-  return upsertGithubAppInstallation(db, teamId, source.installation_id, source.name, userId)
+  return upsertGithubAppInstallation(db, teamId, installationId, source.name, userId)
 }
 
 export async function updateCredential(

--- a/apps/api/src/services/membership.ts
+++ b/apps/api/src/services/membership.ts
@@ -1,0 +1,10 @@
+import type { DB } from "../db/db"
+
+export async function isTeamMember(db: DB, teamId: string, userId: string): Promise<boolean> {
+  const row = await db.selectFrom("team_members")
+    .select("id")
+    .where("team_id", "=", teamId)
+    .where("user_id", "=", userId)
+    .executeTakeFirst()
+  return !!row
+}

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -4,6 +4,7 @@ import type { Selectable, Updateable } from "kysely"
 import type { Database } from "../db/types"
 import { sql } from "kysely"
 import { ServiceError } from "./errors"
+import { isTeamMember } from "./membership"
 
 // ── Internal row type (snake_case, never exported) ────────────────────────────
 
@@ -28,18 +29,6 @@ function mapProject(row: ProjectRow): Project {
 
 function isValidProjectSlug(slug: string): boolean {
   return /^[a-z0-9][a-z0-9-]{0,49}$/.test(slug) && !slug.endsWith("-")
-}
-
-// ── Team membership check ─────────────────────────────────────────────────────
-
-async function isTeamMember(db: DB, teamId: string, userId: string): Promise<boolean> {
-  const row = await db
-    .selectFrom("team_members")
-    .select("id")
-    .where("team_id", "=", teamId)
-    .where("user_id", "=", userId)
-    .executeTakeFirst()
-  return !!row
 }
 
 // ── Service functions ─────────────────────────────────────────────────────────

--- a/apps/api/tests/services/git-credentials.test.ts
+++ b/apps/api/tests/services/git-credentials.test.ts
@@ -2,7 +2,8 @@ import { beforeAll, describe, it, expect } from "vitest"
 import { join } from "path"
 import { runMigrations } from "../../src/db/migrations"
 import { createTestDb } from "../utils/sqlite"
-import { upsertGithubAppInstallation, listTeamCredentials } from "../../src/services/git-credentials"
+import { upsertGithubAppInstallation, listTeamCredentials, listLinkableInstallations, linkInstallationToTeam } from "../../src/services/git-credentials"
+import { ServiceError } from "../../src/services/errors"
 
 const db = createTestDb()
 
@@ -13,89 +14,176 @@ describe("services/git-credentials", () => {
 
     const now = new Date().toISOString()
 
-    await db.insertInto("user").values({
-      id: "userId",
-      name: "Test User",
-      email: "test@example.com",
-      emailVerified: false,
-      image: null,
-      role: "developer",
-      createdAt: now,
-      updatedAt: now,
-    }).execute()
+    await db.insertInto("user").values([
+      { id: "userId", name: "Test User", email: "test@example.com", emailVerified: false, image: null, role: "developer", createdAt: now, updatedAt: now },
+      { id: "otherUserId", name: "Other User", email: "other@example.com", emailVerified: false, image: null, role: "developer", createdAt: now, updatedAt: now },
+    ]).execute()
 
-    await db.insertInto("teams").values({
-      id: "teamId",
-      name: "Test Team",
-      is_personal: false,
-      owner_id: "userId",
-      created_at: now,
-      updated_at: now,
-    }).execute()
+    await db.insertInto("teams").values([
+      { id: "teamId", name: "Test Team", is_personal: false, owner_id: "userId", created_at: now, updated_at: now },
+      { id: "teamBId", name: "Team B", is_personal: false, owner_id: "userId", created_at: now, updated_at: now },
+      { id: "teamCId", name: "Team C (other owner)", is_personal: false, owner_id: "otherUserId", created_at: now, updated_at: now },
+    ]).execute()
 
-    await db.insertInto("team_members").values({
-      id: "memberId",
-      team_id: "teamId",
-      user_id: "userId",
-      created_at: now,
-    }).execute()
+    await db.insertInto("team_members").values([
+      { id: "memberId", team_id: "teamId", user_id: "userId", created_at: now },
+      { id: "memberBId", team_id: "teamBId", user_id: "userId", created_at: now },
+      { id: "memberCOther", team_id: "teamCId", user_id: "otherUserId", created_at: now },
+      // userId is also a member of teamCId (shared team)
+      { id: "memberCUser", team_id: "teamCId", user_id: "userId", created_at: now },
+    ]).execute()
   })
 
   describe("upsertGithubAppInstallation", () => {
     it("creates a new github_app credential for the team", async () => {
-      const cred = await upsertGithubAppInstallation(db, "teamId", "111", "myorg")
+      const cred = await upsertGithubAppInstallation(db, "teamId", "111", "myorg", "userId")
       expect(cred.type).toBe("github_app")
       expect(cred.provider).toBe("github")
-      expect(cred.name).toBe("myorg (GitHub App)")
+      expect(cred.name).toBe("myorg")
       expect(cred.installationId).toBe("111")
       expect(cred.teamId).toBe("teamId")
     })
 
-    it("updates name when called again with the same installation_id", async () => {
-      await upsertGithubAppInstallation(db, "teamId", "222", "original-org")
-      const updated = await upsertGithubAppInstallation(db, "teamId", "222", "renamed-org")
-      expect(updated.name).toBe("renamed-org (GitHub App)")
+    it("stores connected_by_user_id on insert", async () => {
+      await upsertGithubAppInstallation(db, "teamId", "inst-ownership", "ownership-org", "userId")
+      const row = await db.selectFrom("git_credentials").selectAll()
+        .where("installation_id", "=", "inst-ownership").executeTakeFirst()
+      expect(row?.connected_by_user_id).toBe("userId")
+    })
+
+    it("updates name when called again with the same installation_id but does not change connected_by_user_id", async () => {
+      await upsertGithubAppInstallation(db, "teamId", "222", "original-org", "userId")
+      const updated = await upsertGithubAppInstallation(db, "teamId", "222", "renamed-org", "otherUserId")
+      expect(updated.name).toBe("renamed-org")
       expect(updated.installationId).toBe("222")
+      // connected_by_user_id must not have been overwritten
+      const row = await db.selectFrom("git_credentials").selectAll()
+        .where("installation_id", "=", "222").where("team_id", "=", "teamId").executeTakeFirst()
+      expect(row?.connected_by_user_id).toBe("userId")
     })
 
     it("does not create a duplicate when called twice with same installation_id", async () => {
-      await upsertGithubAppInstallation(db, "teamId", "333", "org-a")
-      await upsertGithubAppInstallation(db, "teamId", "333", "org-a")
-      const all = await db
-        .selectFrom("git_credentials")
-        .selectAll()
-        .where("team_id", "=", "teamId")
-        .where("installation_id", "=", "333")
-        .execute()
+      await upsertGithubAppInstallation(db, "teamId", "333", "org-a", "userId")
+      await upsertGithubAppInstallation(db, "teamId", "333", "org-a", "userId")
+      const all = await db.selectFrom("git_credentials").selectAll()
+        .where("team_id", "=", "teamId").where("installation_id", "=", "333").execute()
       expect(all.length).toBe(1)
     })
 
     it("allows multiple installations with different installation_ids on the same team", async () => {
-      await upsertGithubAppInstallation(db, "teamId", "444", "org-one")
-      await upsertGithubAppInstallation(db, "teamId", "555", "org-two")
-      const all = await db
-        .selectFrom("git_credentials")
-        .selectAll()
-        .where("team_id", "=", "teamId")
-        .where("installation_id", "in", ["444", "555"])
-        .execute()
+      await upsertGithubAppInstallation(db, "teamId", "444", "org-one", "userId")
+      await upsertGithubAppInstallation(db, "teamId", "555", "org-two", "userId")
+      const all = await db.selectFrom("git_credentials").selectAll()
+        .where("team_id", "=", "teamId").where("installation_id", "in", ["444", "555"]).execute()
       expect(all.length).toBe(2)
     })
   })
 
   describe("listTeamCredentials", () => {
     it("includes installationId in the response for github_app credentials", async () => {
-      await upsertGithubAppInstallation(db, "teamId", "999", "listed-org")
+      await upsertGithubAppInstallation(db, "teamId", "999", "listed-org", "userId")
       const creds = await listTeamCredentials(db, "teamId", "userId")
       const appCred = creds?.find((c) => c.installationId === "999")
       expect(appCred).toBeDefined()
       expect(appCred?.type).toBe("github_app")
-      expect(appCred?.name).toBe("listed-org (GitHub App)")
+      expect(appCred?.name).toBe("listed-org")
     })
 
     it("returns null when user is not a team member", async () => {
       const result = await listTeamCredentials(db, "teamId", "nonexistent-user")
       expect(result).toBeNull()
+    })
+  })
+
+  describe("listLinkableInstallations", () => {
+    beforeAll(async () => {
+      // userId connected inst-link-A on teamId, inst-link-B on teamBId
+      await upsertGithubAppInstallation(db, "teamId", "inst-link-A", "link-org-A", "userId")
+      await upsertGithubAppInstallation(db, "teamBId", "inst-link-B", "link-org-B", "userId")
+      // otherUserId connected inst-link-C on teamCId (userId is also a member of teamCId)
+      await upsertGithubAppInstallation(db, "teamCId", "inst-link-C", "link-org-C", "otherUserId")
+    })
+
+    it("returns installations the user personally connected on other teams", async () => {
+      // From teamBId's perspective: userId connected inst-link-A on teamId
+      const result = await listLinkableInstallations(db, "teamBId", "userId")
+      const names = result.map((r) => r.name)
+      expect(names).toContain("link-org-A")
+    })
+
+    it("excludes installations connected by a different user even on a shared team", async () => {
+      // userId is a member of teamCId but did NOT connect inst-link-C (otherUserId did)
+      const result = await listLinkableInstallations(db, "teamBId", "userId")
+      const names = result.map((r) => r.name)
+      expect(names).not.toContain("link-org-C")
+    })
+
+    it("excludes installations already linked to the target team", async () => {
+      // inst-link-A is already on teamId — should not appear when querying from teamId
+      const result = await listLinkableInstallations(db, "teamId", "userId")
+      const names = result.map((r) => r.name)
+      expect(names).not.toContain("link-org-A")
+    })
+
+    it("returns empty array when caller is not a member of teamId", async () => {
+      const result = await listLinkableInstallations(db, "teamId", "nonexistent-user")
+      expect(result).toEqual([])
+    })
+
+    it("deduplicates when same installationId appears in multiple teams connected by the same user", async () => {
+      // Link inst-link-A to teamBId as well (same user)
+      await upsertGithubAppInstallation(db, "teamBId", "inst-link-A", "link-org-A", "userId")
+      // Now from teamId's perspective, inst-link-A is on teamBId — should appear only once
+      const result = await listLinkableInstallations(db, "teamId", "userId")
+      const matchingA = result.filter((r) => r.name === "link-org-A")
+      expect(matchingA.length).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe("linkInstallationToTeam", () => {
+    let credToLinkId: string
+    let credOtherLinkId: string
+
+    beforeAll(async () => {
+      // userId connected inst-to-link on teamId
+      const a = await upsertGithubAppInstallation(db, "teamId", "inst-to-link", "to-link-org", "userId")
+      credToLinkId = a.id
+      // otherUserId connected inst-other-link on teamCId
+      const b = await upsertGithubAppInstallation(db, "teamCId", "inst-other-link", "other-link-org", "otherUserId")
+      credOtherLinkId = b.id
+    })
+
+    it("links an installation the user personally connected to another team they belong to", async () => {
+      const cred = await linkInstallationToTeam(db, "teamBId", "userId", credToLinkId)
+      expect(cred.teamId).toBe("teamBId")
+      expect(cred.installationId).toBe("inst-to-link")
+      expect(cred.name).toBe("to-link-org")
+    })
+
+    it("rejects a credential connected by a different user even if caller shares a team", async () => {
+      // userId is a member of teamCId but did NOT connect inst-other-link
+      await expect(
+        linkInstallationToTeam(db, "teamId", "userId", credOtherLinkId)
+      ).rejects.toThrow(ServiceError)
+    })
+
+    it("rejects a nonexistent credential id", async () => {
+      await expect(
+        linkInstallationToTeam(db, "teamBId", "userId", "00000000-0000-0000-0000-000000000000")
+      ).rejects.toThrow(ServiceError)
+    })
+
+    it("rejects when caller is not a member of the target team", async () => {
+      await expect(
+        linkInstallationToTeam(db, "nonexistent-team", "userId", credToLinkId)
+      ).rejects.toThrow(ServiceError)
+    })
+
+    it("is idempotent: re-linking returns existing credential without error", async () => {
+      // inst-to-link was already linked to teamBId in the first test
+      const cred = await linkInstallationToTeam(db, "teamBId", "userId", credToLinkId)
+      expect(cred.installationId).toBe("inst-to-link")
+      expect(cred.teamId).toBe("teamBId")
     })
   })
 })

--- a/apps/api/tests/services/git-credentials.test.ts
+++ b/apps/api/tests/services/git-credentials.test.ts
@@ -107,22 +107,22 @@ describe("services/git-credentials", () => {
     it("returns installations the user personally connected on other teams", async () => {
       // From teamBId's perspective: userId connected inst-link-A on teamId
       const result = await listLinkableInstallations(db, "teamBId", "userId")
-      const names = result.map((r) => r.name)
-      expect(names).toContain("link-org-A")
+      const ids = result.map((r) => r.installationId)
+      expect(ids).toContain("inst-link-A")
     })
 
     it("excludes installations connected by a different user even on a shared team", async () => {
       // userId is a member of teamCId but did NOT connect inst-link-C (otherUserId did)
       const result = await listLinkableInstallations(db, "teamBId", "userId")
-      const names = result.map((r) => r.name)
-      expect(names).not.toContain("link-org-C")
+      const ids = result.map((r) => r.installationId)
+      expect(ids).not.toContain("inst-link-C")
     })
 
     it("excludes installations already linked to the target team", async () => {
       // inst-link-A is already on teamId — should not appear when querying from teamId
       const result = await listLinkableInstallations(db, "teamId", "userId")
-      const names = result.map((r) => r.name)
-      expect(names).not.toContain("link-org-A")
+      const ids = result.map((r) => r.installationId)
+      expect(ids).not.toContain("inst-link-A")
     })
 
     it("returns empty array when caller is not a member of teamId", async () => {
@@ -135,53 +135,48 @@ describe("services/git-credentials", () => {
       await upsertGithubAppInstallation(db, "teamBId", "inst-link-A", "link-org-A", "userId")
       // Now from teamId's perspective, inst-link-A is on teamBId — should appear only once
       const result = await listLinkableInstallations(db, "teamId", "userId")
-      const matchingA = result.filter((r) => r.name === "link-org-A")
+      const matchingA = result.filter((r) => r.installationId === "inst-link-A")
       expect(matchingA.length).toBeLessThanOrEqual(1)
     })
   })
 
   describe("linkInstallationToTeam", () => {
-    let credToLinkId: string
-    let credOtherLinkId: string
-
     beforeAll(async () => {
       // userId connected inst-to-link on teamId
-      const a = await upsertGithubAppInstallation(db, "teamId", "inst-to-link", "to-link-org", "userId")
-      credToLinkId = a.id
+      await upsertGithubAppInstallation(db, "teamId", "inst-to-link", "to-link-org", "userId")
       // otherUserId connected inst-other-link on teamCId
-      const b = await upsertGithubAppInstallation(db, "teamCId", "inst-other-link", "other-link-org", "otherUserId")
-      credOtherLinkId = b.id
+      await upsertGithubAppInstallation(db, "teamCId", "inst-other-link", "other-link-org", "otherUserId")
     })
 
     it("links an installation the user personally connected to another team they belong to", async () => {
-      const cred = await linkInstallationToTeam(db, "teamBId", "userId", credToLinkId)
+      const cred = await linkInstallationToTeam(db, "teamBId", "userId", "inst-to-link")
       expect(cred.teamId).toBe("teamBId")
       expect(cred.installationId).toBe("inst-to-link")
       expect(cred.name).toBe("to-link-org")
     })
 
-    it("rejects a credential connected by a different user even if caller shares a team", async () => {
+    it("rejects an installationId connected by a different user even if caller shares a team", async () => {
       // userId is a member of teamCId but did NOT connect inst-other-link
       await expect(
-        linkInstallationToTeam(db, "teamId", "userId", credOtherLinkId)
+        linkInstallationToTeam(db, "teamId", "userId", "inst-other-link")
       ).rejects.toThrow(ServiceError)
     })
 
-    it("rejects a nonexistent credential id", async () => {
+    it("rejects a nonexistent installationId", async () => {
       await expect(
-        linkInstallationToTeam(db, "teamBId", "userId", "00000000-0000-0000-0000-000000000000")
+        linkInstallationToTeam(db, "teamBId", "userId", "inst-does-not-exist")
       ).rejects.toThrow(ServiceError)
     })
 
     it("rejects when caller is not a member of the target team", async () => {
       await expect(
-        linkInstallationToTeam(db, "nonexistent-team", "userId", credToLinkId)
+        linkInstallationToTeam(db, "nonexistent-team", "userId", "inst-to-link")
       ).rejects.toThrow(ServiceError)
     })
 
     it("is idempotent: re-linking returns existing credential without error", async () => {
       // inst-to-link was already linked to teamBId in the first test
-      const cred = await linkInstallationToTeam(db, "teamBId", "userId", credToLinkId)
+      const cred = await linkInstallationToTeam(db, "teamBId", "userId", "inst-to-link")
       expect(cred.installationId).toBe("inst-to-link")
       expect(cred.teamId).toBe("teamBId")
     })

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@canette/types": "workspace:*",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/ui/src/app/(authenticated)/admin/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/page.tsx
@@ -320,9 +320,9 @@ export default function AdminPage() {
                 ) : (
                   <>
                     <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
-                      <span className="text-xs text-muted-foreground flex-1">NAME</span>
-                      <span className="text-xs text-muted-foreground w-20 text-right">MEMBERS</span>
-                      <span className="text-xs text-muted-foreground w-20 text-right">PROJECTS</span>
+                      <span className="text-xs text-muted-foreground uppercase flex-1">Name</span>
+                      <span className="text-xs text-muted-foreground uppercase w-20 text-right">Members</span>
+                      <span className="text-xs text-muted-foreground uppercase w-20 text-right">Projects</span>
                     </div>
                     {adminTeams.map((team, i) => (
                       <div key={team.id}>

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/[appSlug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/[appSlug]/page.tsx
@@ -481,8 +481,8 @@ function EnvCard({ appId, open, onToggle }: { appId: string; open: boolean; onTo
             {hasItems && (
               <>
                 <div className="px-6 py-1.5 flex items-center gap-3 border-b border-border/50">
-                  <span className="font-mono text-xs text-muted-foreground w-48">KEY</span>
-                  <span className="text-xs text-muted-foreground">VALUE</span>
+                  <span className="font-mono text-xs text-muted-foreground uppercase w-48">Key</span>
+                  <span className="text-xs text-muted-foreground uppercase">Value</span>
                 </div>
                 {envVars.map((v) => (
                   <EnvRow

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
@@ -5,8 +5,10 @@ import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
 import { AppShell } from "@/components/app-shell"
@@ -79,6 +81,9 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   // GitHub App installation
   const [connectingGithubApp, setConnectingGithubApp] = useState(false)
   const [githubAppNotice, setGithubAppNotice] = useState<string | null>(null)
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false)
+  const [linkableInstallations, setLinkableInstallations] = useState<{ id: string; name: string }[]>([])
+  const [linkingInstallationId, setLinkingInstallationId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     try {
@@ -191,6 +196,29 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   async function handleConnectGithubApp() {
     setConnectingGithubApp(true)
     try {
+      const { installations } = await api.githubApp.getLinkableInstallations(teamId)
+      if (installations.length > 0) {
+        setLinkableInstallations(installations)
+        setLinkDialogOpen(true)
+        return
+      }
+      const result = await api.githubApp.getInstallUrl(teamId)
+      if (!result.available || !result.url) {
+        setGithubAppNotice("Per-Team GitHub App support is not configured on this instance. Ask your admin to set it up.")
+        return
+      }
+      window.location.href = result.url
+    } catch {
+      setGithubAppNotice("Failed to get GitHub App install URL. Please try again.")
+    } finally {
+      setConnectingGithubApp(false)
+    }
+  }
+
+  async function handleConnectNewAccount() {
+    setLinkDialogOpen(false)
+    setConnectingGithubApp(true)
+    try {
       const result = await api.githubApp.getInstallUrl(teamId)
       if (!result.available || !result.url) {
         setGithubAppNotice("Per-Team GitHub App support is not configured on this instance. Ask your admin to set it up.")
@@ -201,6 +229,21 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
       setGithubAppNotice("Failed to get GitHub App install URL. Please try again.")
     } finally {
       setTimeout(() => setConnectingGithubApp(false), 2000)
+    }
+  }
+
+  async function handleLinkInstallation(credentialId: string) {
+    setLinkingInstallationId(credentialId)
+    try {
+      const cred = await api.githubApp.linkInstallation(teamId, credentialId)
+      setCredentials((prev) => [cred, ...prev])
+      setLinkableInstallations((prev) => prev.filter((i) => i.id !== credentialId))
+      if (linkableInstallations.length <= 1) setLinkDialogOpen(false)
+      setGithubAppNotice("GitHub App installation linked to this team.")
+    } catch (e) {
+      setGithubAppNotice(e instanceof Error ? e.message : "Failed to link installation.")
+    } finally {
+      setLinkingInstallationId(null)
     }
   }
 
@@ -264,8 +307,8 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
             {!team.isPersonal && members.length > 0 && (
               <>
                 <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
-                  <span className="text-xs text-muted-foreground flex-1">NAME / EMAIL</span>
-                  <span className="text-xs text-muted-foreground w-20">JOINED</span>
+                  <span className="text-xs text-muted-foreground uppercase flex-1">Name / Email</span>
+                  <span className="text-xs text-muted-foreground uppercase w-20">Joined</span>
                   {isAdmin && <span className="w-7" />}
                 </div>
                 {members.map((member, i) => (
@@ -332,10 +375,10 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
             {teamCreds.length > 0 && (
               <>
                 <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
-                  <span className="text-xs text-muted-foreground w-48">NAME</span>
-                  <span className="text-xs text-muted-foreground w-20">PROVIDER</span>
-                  <span className="text-xs text-muted-foreground w-24">TYPE</span>
-                  <span className="text-xs text-muted-foreground flex-1">ADDED</span>
+                  <span className="text-xs text-muted-foreground uppercase w-48">Name</span>
+                  <span className="text-xs text-muted-foreground uppercase w-20">Provider</span>
+                  <span className="text-xs text-muted-foreground uppercase w-24">Type</span>
+                  <span className="text-xs text-muted-foreground uppercase flex-1">Added</span>
                 </div>
                 {teamCreds.map((cred, i) => (
                   <div key={cred.id}>
@@ -435,15 +478,16 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <Label>Provider</Label>
-                  <select
-                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-                    value={credProvider}
-                    onChange={(e) => setCredProvider(e.target.value as GitProvider)}
-                  >
-                    {PROVIDERS.map((p) => (
-                      <option key={p.value} value={p.value}>{p.label}</option>
-                    ))}
-                  </select>
+                  <Select value={credProvider} onValueChange={(v) => setCredProvider(v as GitProvider)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROVIDERS.map((p) => (
+                        <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
 
@@ -554,15 +598,23 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
             </CardHeader>
             <CardContent className="p-0">
               {githubAppNotice && (
-                <div className="px-6 py-3 bg-muted/40 border-b border-border/50">
+                <div className="px-6 py-3 bg-muted/40 border-b border-border/50 flex items-center justify-between gap-4">
                   <p className="text-sm text-muted-foreground">{githubAppNotice}</p>
+                  <button
+                    type="button"
+                    onClick={() => setGithubAppNotice(null)}
+                    className="text-muted-foreground hover:text-foreground shrink-0"
+                    aria-label="Dismiss"
+                  >
+                    ×
+                  </button>
                 </div>
               )}
 
               {systemGithubApp && (
                 <>
                   <div className="px-6 py-3 border-b border-border/50">
-                    <p className="text-xs text-muted-foreground font-medium mb-2">SYSTEM INSTALLATION</p>
+                    <p className="text-xs text-muted-foreground uppercase font-medium mb-2">System installation</p>
                     <div className="flex items-center gap-4">
                       <span className="text-sm font-medium flex-1">{systemGithubApp.name}</span>
                       <Badge variant="secondary" className="text-xs">configured by admin</Badge>
@@ -575,8 +627,9 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
               {teamGithubAppCreds.length > 0 && (
                 <>
                   <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
-                    <span className="text-xs text-muted-foreground flex-1">TEAM INSTALLATIONS</span>
-                    <span className="text-xs text-muted-foreground w-20">CONNECTED</span>
+                    <span className="text-xs text-muted-foreground uppercase flex-1">Team installations</span>
+                    <span className="w-20" />
+                    <span className="text-xs text-muted-foreground uppercase w-20 text-right">Connected</span>
                     <span className="w-7" />
                   </div>
                   {teamGithubAppCreds.map((cred, i) => (
@@ -584,7 +637,20 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                       {i > 0 && <Separator />}
                       <div className="flex items-center gap-4 px-6 py-3 group">
                         <span className="text-sm font-medium flex-1 truncate">{cred.name}</span>
-                        <span className="text-xs text-muted-foreground w-20">{timeAgo(cred.createdAt)}</span>
+                        {cred.installationId && cred.connectedByUserId === session?.user?.id ? (
+                          <a
+                            href={`https://github.com/settings/installations/${cred.installationId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-muted-foreground hover:text-foreground w-20 text-right opacity-0 group-hover:opacity-100"
+                            title="Configure repo access on GitHub"
+                          >
+                            Configure ↗
+                          </a>
+                        ) : (
+                          <span className="w-20" />
+                        )}
+                        <span className="text-xs text-muted-foreground w-20 text-right">{timeAgo(cred.createdAt)}</span>
                         <Button
                           size="sm"
                           variant="ghost"
@@ -617,6 +683,50 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
         )}
 
       </div>
+
+      <Dialog open={linkDialogOpen} onOpenChange={setLinkDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Connect GitHub App</DialogTitle>
+            <DialogDescription>
+              Link your existing Github App to this team or connect a new GitHub account or org.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="px-6 pb-2 flex flex-col gap-2">
+            <p className="text-xs text-amber-600 dark:text-amber-500 border-l-2 border-amber-400 pl-2 leading-relaxed mb-2">
+              GitHub App permissions apply to all teams — you cannot restrict access per team. For fine-grained per-team access control, use fine-grained PAT tokens instead.
+            </p>
+            <p className="text-xs text-muted-foreground uppercase font-medium">Your installations</p>
+            {linkableInstallations.map((inst) => (
+              <div key={inst.id} className="flex items-center gap-3 py-1">
+                <span className="text-sm flex-1">{inst.name}</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleLinkInstallation(inst.id)}
+                  disabled={linkingInstallationId === inst.id}
+                >
+                  {linkingInstallationId === inst.id
+                    ? <Loader2 className="size-4 animate-spin" />
+                    : "Link to this team"}
+                </Button>
+              </div>
+            ))}
+          </div>
+          <div className="px-6 pb-6 pt-2 border-t border-border/50 mt-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={handleConnectNewAccount}
+            >
+              <GitHubIcon size={15} />
+              Connect a different account or org
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
     </AppShell>
   )
 }

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   const [connectingGithubApp, setConnectingGithubApp] = useState(false)
   const [githubAppNotice, setGithubAppNotice] = useState<string | null>(null)
   const [linkDialogOpen, setLinkDialogOpen] = useState(false)
-  const [linkableInstallations, setLinkableInstallations] = useState<{ id: string; name: string }[]>([])
+  const [linkableInstallations, setLinkableInstallations] = useState<{ installationId: string; name: string }[]>([])
   const [linkingInstallationId, setLinkingInstallationId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
@@ -232,12 +232,12 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     }
   }
 
-  async function handleLinkInstallation(credentialId: string) {
-    setLinkingInstallationId(credentialId)
+  async function handleLinkInstallation(installationId: string) {
+    setLinkingInstallationId(installationId)
     try {
-      const cred = await api.githubApp.linkInstallation(teamId, credentialId)
+      const cred = await api.githubApp.linkInstallation(teamId, installationId)
       setCredentials((prev) => [cred, ...prev])
-      setLinkableInstallations((prev) => prev.filter((i) => i.id !== credentialId))
+      setLinkableInstallations((prev) => prev.filter((i) => i.installationId !== installationId))
       if (linkableInstallations.length <= 1) setLinkDialogOpen(false)
       setGithubAppNotice("GitHub App installation linked to this team.")
     } catch (e) {
@@ -698,15 +698,15 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
             </p>
             <p className="text-xs text-muted-foreground uppercase font-medium">Your installations</p>
             {linkableInstallations.map((inst) => (
-              <div key={inst.id} className="flex items-center gap-3 py-1">
+              <div key={inst.installationId} className="flex items-center gap-3 py-1">
                 <span className="text-sm flex-1">{inst.name}</span>
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => handleLinkInstallation(inst.id)}
-                  disabled={linkingInstallationId === inst.id}
+                  onClick={() => handleLinkInstallation(inst.installationId)}
+                  disabled={linkingInstallationId === inst.installationId}
                 >
-                  {linkingInstallationId === inst.id
+                  {linkingInstallationId === inst.installationId
                     ? <Loader2 className="size-4 animate-spin" />
                     : "Link to this team"}
                 </Button>

--- a/apps/ui/src/components/credential-select.tsx
+++ b/apps/ui/src/components/credential-select.tsx
@@ -27,6 +27,9 @@ export function CredentialSelect({ credentials, value, onChange, id = "gitCreden
             <SelectItem key={c.id} value={c.id} textValue={c.name}>
               <span className="flex items-center gap-2">
                 {c.name}
+                {c.type === "github_app" && (
+                  <Badge variant="secondary" className="text-xs font-normal">GitHub App</Badge>
+                )}
                 {c.teamId === null && (
                   <Badge variant="secondary" className="text-xs font-normal">system</Badge>
                 )}

--- a/apps/ui/src/components/user-menu.tsx
+++ b/apps/ui/src/components/user-menu.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import Image from "next/image"
+import * as Avatar from "@radix-ui/react-avatar"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { signOut } from "@/lib/auth-client"
@@ -34,25 +34,19 @@ export function UserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="relative flex items-center justify-center h-8 w-8 rounded-full bg-muted hover:bg-muted/80 border border-border text-xs font-semibold overflow-hidden transition-colors"
+        <Avatar.Root
+          className="relative flex items-center justify-center h-8 w-8 rounded-md bg-muted hover:bg-muted/80 border border-border overflow-hidden transition-colors cursor-pointer"
           aria-label="User menu"
         >
-          {user.image ? (
-            // next/image validates the URL against remotePatterns in next.config.ts,
-            // preventing arbitrary external image sources.
-            <Image
-              src={user.image}
-              alt={user.name}
-              width={32}
-              height={32}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <span>{initials(user.name)}</span>
-          )}
-        </button>
+          <Avatar.Image
+            src={user.image ?? undefined}
+            alt={user.name}
+            className="h-full w-full object-cover"
+          />
+          <Avatar.Fallback className="flex items-center justify-center h-full w-full text-xs font-semibold">
+            {initials(user.name)}
+          </Avatar.Fallback>
+        </Avatar.Root>
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -56,6 +56,10 @@ export const teams = {
 export const githubApp = {
   getInstallUrl: (teamId: string) =>
     request<{ available: boolean; url?: string }>(`/github-app/install-url?teamId=${teamId}`),
+  getLinkableInstallations: (teamId: string) =>
+    request<{ installations: { id: string; name: string }[] }>(`/github-app/linkable?teamId=${teamId}`),
+  linkInstallation: (teamId: string, credentialId: string) =>
+    request<GitCredential>(`/github-app/link`, { method: "POST", body: JSON.stringify({ teamId, credentialId }) }),
 }
 
 // Projects

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -57,9 +57,9 @@ export const githubApp = {
   getInstallUrl: (teamId: string) =>
     request<{ available: boolean; url?: string }>(`/github-app/install-url?teamId=${teamId}`),
   getLinkableInstallations: (teamId: string) =>
-    request<{ installations: { id: string; name: string }[] }>(`/github-app/linkable?teamId=${teamId}`),
-  linkInstallation: (teamId: string, credentialId: string) =>
-    request<GitCredential>(`/github-app/link`, { method: "POST", body: JSON.stringify({ teamId, credentialId }) }),
+    request<{ installations: { installationId: string; name: string }[] }>(`/github-app/linkable?teamId=${teamId}`),
+  linkInstallation: (teamId: string, installationId: string) =>
+    request<GitCredential>(`/github-app/link`, { method: "POST", body: JSON.stringify({ teamId, installationId }) }),
 }
 
 // Projects

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@canette/types": "workspace:*",
+        "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -370,6 +371,8 @@
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 
+    "@radix-ui/react-avatar": ["@radix-ui/react-avatar@1.1.11", "", { "dependencies": { "@radix-ui/react-context": "1.1.3", "@radix-ui/react-primitive": "2.1.4", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q=="],
+
     "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
 
     "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
@@ -378,7 +381,7 @@
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
-    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
     "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
 
@@ -406,7 +409,7 @@
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
 
-    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA=="],
 
@@ -429,6 +432,8 @@
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.0", "", { "dependencies": { "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
@@ -1722,6 +1727,8 @@
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
@@ -1778,8 +1785,6 @@
 
     "@canette/ui/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "@canette/ui/lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
@@ -1790,21 +1795,87 @@
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
+    "@radix-ui/react-accordion/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-accordion/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-checkbox/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-checkbox/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-collapsible/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-collapsible/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
     "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+    "@radix-ui/react-popper/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-scroll-area/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-scroll-area/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-select/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-select/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+    "@radix-ui/react-tabs/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -1913,6 +1984,34 @@
     "@eslint/eslintrc/espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "@radix-ui/react-accordion/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-checkbox/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-collapsible/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-dropdown-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-navigation-menu/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-scroll-area/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@types/pg/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -51,7 +51,8 @@ export interface GitCredential {
   name: string
   provider: GitProvider
   type: GitCredentialType
-  installationId?: string  // only present for github_app type (per-team installations)
+  installationId?: string    // only present for github_app type (per-team installations)
+  connectedByUserId?: string // only present for github_app type (per-team installations)
   createdAt: string
   // encrypted_value is never returned by the API
 }


### PR DESCRIPTION
## Summary

**Rework — GitHub App link flow to support multiple teams:**

Turns out managing Github credentials is hard.

This PR adds support for adding the same Github App to multiple teams (if the users wishes to do so). Previously the UI would redirect to Github that would show the existing Github App install, already linked to another team. Now the user is given the option to link the app to the selected team. The dialog includes a warning about this might not being a good idea.

**Fixes**

- **Provider dropdown**: replaced native `<select>` with Radix `Select` to match the rest of the form styling
- **Column headers**: CSS `text-transform: uppercase` instead of hardcoded ALL CAPS across all table headers
- **GitHub App table**: date right-aligned; Configure link only visible to the user who connected the installation (`connectedByUserId`)
- **Link dialog**: amber warning that GitHub App permissions are shared across all teams, with a recommendation to use fine-grained PATs for per-team access control; fixed spacing around warning
- **Credential select**: GitHub App badge added alongside the existing system badge
- **User menu**: switched to Radix Avatar primitive

🤖 As always, this code was not written all by hand.