### PR TITLE
chore: align user IDs to UUID standard

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -9,6 +9,11 @@ export const auth = betterAuth({
   database: pool,
   secret: process.env.BETTER_AUTH_SECRET,
   trustedOrigins: [process.env.UI_URL ?? "http://localhost:3000"],
+  advanced: {
+    database: {
+      generateId: "uuid",
+    },
+  },
   socialProviders: {
     ...(process.env.GITHUB_CLIENT_ID
       ? {

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -5,15 +5,32 @@ import { passwordPolicyPlugin } from "./password"
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 
+export const coreAuthOptions = {
+  advanced: {
+    database: {
+      generateId: "uuid" as const,
+    },
+  },
+  plugins: [passwordPolicyPlugin(), admin({ adminRole: "admin", defaultRole: "developer" })],
+  emailAndPassword: {
+    enabled: true,
+  },
+  user: {
+    additionalFields: {
+      role: {
+        type: "string" as const,
+        defaultValue: "developer",
+        input: false,
+      },
+    },
+  },
+}
+
 export const auth = betterAuth({
+  ...coreAuthOptions,
   database: pool,
   secret: process.env.BETTER_AUTH_SECRET,
   trustedOrigins: [process.env.UI_URL ?? "http://localhost:3000"],
-  advanced: {
-    database: {
-      generateId: "uuid",
-    },
-  },
   socialProviders: {
     ...(process.env.GITHUB_CLIENT_ID
       ? {
@@ -31,19 +48,6 @@ export const auth = betterAuth({
           },
         }
       : {}),
-  },
-  plugins: [passwordPolicyPlugin(), admin({ adminRole: "admin", defaultRole: "developer" })],
-  emailAndPassword: {
-    enabled: true,
-  },
-  user: {
-    additionalFields: {
-      role: {
-        type: "string" as const,
-        defaultValue: "developer",
-        input: false,
-      },
-    },
   },
   databaseHooks: {
     user: {

--- a/apps/api/tests/auth/auth.test.ts
+++ b/apps/api/tests/auth/auth.test.ts
@@ -2,21 +2,17 @@ import { beforeAll, describe, it, expect } from "vitest"
 import { Database } from "bun:sqlite"
 import { betterAuth } from "better-auth"
 import { getMigrations } from "better-auth/db/migration"
+import { coreAuthOptions } from "../../src/auth/auth"
+import { PASSWORD_REQUIREMENTS } from "../../src/auth/password"
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function createTestAuth() {
-  const db = new Database(":memory:")
   return betterAuth({
+    ...coreAuthOptions,
     baseURL: "http://localhost:3000",
     secret: "test-secret-that-is-long-enough-for-validation",
-    database: db,
-    emailAndPassword: { enabled: true },
-    advanced: {
-      database: {
-        generateId: "uuid",
-      },
-    },
+    database: new Database(":memory:"),
   })
 }
 
@@ -34,10 +30,38 @@ describe("auth", () => {
       body: {
         name: "Test User",
         email: "test@example.com",
-        password: "password123456",
+        password: "Password123456!",
       },
     })
 
     expect(res.user.id).toMatch(UUID_RE)
+  })
+
+  it.each([
+    ["short",          "Ab1!"],
+    ["no uppercase",   "password123456"],
+    ["no lowercase",   "PASSWORD123456"],
+    ["no number",      "PasswordABCDEF"],
+  ])("rejects weak password: %s", async (_label, password) => {
+    await expect(
+      auth.api.signUpEmail({
+        body: { name: "Test User", email: "weak@example.com", password },
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it("password requirements stay in sync with PASSWORD_REQUIREMENTS", () => {
+    expect(PASSWORD_REQUIREMENTS).toContainEqual(
+      expect.objectContaining({ label: expect.stringMatching(/12 characters/) }),
+    )
+    expect(PASSWORD_REQUIREMENTS).toContainEqual(
+      expect.objectContaining({ label: expect.stringMatching(/uppercase/) }),
+    )
+    expect(PASSWORD_REQUIREMENTS).toContainEqual(
+      expect.objectContaining({ label: expect.stringMatching(/lowercase/) }),
+    )
+    expect(PASSWORD_REQUIREMENTS).toContainEqual(
+      expect.objectContaining({ label: expect.stringMatching(/number/) }),
+    )
   })
 })

--- a/apps/api/tests/auth/auth.test.ts
+++ b/apps/api/tests/auth/auth.test.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, it, expect } from "vitest"
+import { Database } from "bun:sqlite"
+import { betterAuth } from "better-auth"
+import { getMigrations } from "better-auth/db/migration"
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function createTestAuth() {
+  const db = new Database(":memory:")
+  return betterAuth({
+    baseURL: "http://localhost:3000",
+    secret: "test-secret-that-is-long-enough-for-validation",
+    database: db,
+    emailAndPassword: { enabled: true },
+    advanced: {
+      database: {
+        generateId: "uuid",
+      },
+    },
+  })
+}
+
+describe("auth", () => {
+  let auth: ReturnType<typeof createTestAuth>
+
+  beforeAll(async () => {
+    auth = createTestAuth()
+    const { runMigrations } = await getMigrations(auth.options)
+    await runMigrations()
+  })
+
+  it("generates UUID-format IDs for new users", async () => {
+    const res = await auth.api.signUpEmail({
+      body: {
+        name: "Test User",
+        email: "test@example.com",
+        password: "password123456",
+      },
+    })
+
+    expect(res.user.id).toMatch(UUID_RE)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `advanced.database.generateId: "uuid"` to the `betterAuth` config — new user registrations will produce standard UUIDs instead of better-auth's default 32-char alphanumeric strings
- Adds an integration test that creates a user via `auth.api.signUpEmail()` against an in-memory SQLite instance and asserts the returned ID matches the UUID v4 format
- No migration included for existing users (see issue discussion)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)