### PR TITLE
fix: user deletion flow, namespace cleanup, and RBAC fixes

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -8,7 +8,7 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 export const coreAuthOptions = {
   advanced: {
     database: {
-      generateId: "uuid" as const,
+      generateId: () => crypto.randomUUID(),
     },
   },
   plugins: [passwordPolicyPlugin(), admin({ adminRole: "admin", defaultRole: "developer" })],

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,6 +12,8 @@ import {
   getProjectsOverview,
   getResourceDefaults,
   getScanPolicy,
+  getTeamMembersForAdmin,
+  getUserDeletionImpact,
   getWebhookSettings,
   listUsers,
   resetStuckBuilds,
@@ -84,12 +86,26 @@ adminRouter.post("/users/:id/reset-password", async (c) => {
   }
 })
 
+// Get deletion impact summary for a user (projects, apps, in-flight builds)
+// GET /api/v1/admin/users/:id/deletion-impact
+adminRouter.get("/users/:id/deletion-impact", async (c) => {
+  try {
+    const impact = await getUserDeletionImpact(db, c.req.param("id"))
+    return c.json(impact)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})
+
 // Delete a user
 // DELETE /api/v1/admin/users/:id
+// Body: { force?: boolean } — required when user has projects; stops live apps and cascades
 adminRouter.delete("/users/:id", async (c) => {
   const session = c.get("session")
+  const body = await c.req.json<{ force?: boolean }>().catch(() => ({} as { force?: boolean }))
   try {
-    const deleted = await deleteUser(db, c.req.param("id"), session.user.id)
+    const deleted = await deleteUser(db, c.req.param("id"), session.user.id, { force: body.force })
     if (!deleted) return c.json({ error: "Not found", code: "NOT_FOUND" }, 404)
     return c.body(null, 204)
   } catch (e) {
@@ -110,6 +126,14 @@ adminRouter.get("/overview", async (c) => {
 adminRouter.get("/teams", async (c) => {
   const teams = await listTeamsOverview(db)
   return c.json(teams)
+})
+
+// Get members of any team (admin, no membership required)
+// GET /api/v1/admin/teams/:id/members
+adminRouter.get("/teams/:id/members", async (c) => {
+  const members = await getTeamMembersForAdmin(db, c.req.param("id"))
+  if (!members) return c.json({ error: "Not found", code: "NOT_FOUND" }, 404)
+  return c.json(members)
 })
 
 // Force-sync: re-queue all live apps for reconciliation

--- a/apps/api/src/services/admin.ts
+++ b/apps/api/src/services/admin.ts
@@ -1,9 +1,10 @@
 import type { DB } from "../db/db"
-import type { AdminAppSummary, AdminProjectOverview, DeploymentStatus, ResourceDefaults, ScanPolicy, SyncResult, User, UserRole, WebhookSettings } from "@canette/types"
+import type { AdminAppSummary, AdminProjectOverview, DeploymentStatus, ResourceDefaults, ScanPolicy, SyncResult, TeamMember, User, UserDeletionImpact, UserRole, WebhookSettings } from "@canette/types"
 import type { Selectable } from "kysely"
 import type { Database } from "../db/types"
 import { sql } from "kysely"
 import { ServiceError } from "./errors"
+import { appNamespace } from "../utils/k8s"
 
 // ── Users ─────────────────────────────────────────────────────────────────────
 
@@ -96,33 +97,201 @@ export async function updateUserRole(
   return mapUser(row)
 }
 
+export async function getUserDeletionImpact(db: DB, userId: string): Promise<UserDeletionImpact> {
+  const [personalTeam, sharedTeams] = await Promise.all([
+    db.selectFrom("teams").select(["id"]).where("owner_id", "=", userId).where("is_personal", "=", true).executeTakeFirst(),
+    db.selectFrom("teams").select("name").where("owner_id", "=", userId).where("is_personal", "=", false).execute(),
+  ])
+
+  let personalTeamImpact: UserDeletionImpact["personalTeam"] = null
+  if (personalTeam) {
+    const projects = await db
+      .selectFrom("projects")
+      .select("id")
+      .where("team_id", "=", personalTeam.id)
+      .execute()
+
+    let appCount = 0
+    const inFlightAppNames: string[] = []
+
+    if (projects.length > 0) {
+      const projectIds = projects.map((p) => p.id)
+      const apps = await db
+        .selectFrom("apps")
+        .select(["id", "name"])
+        .where("project_id", "in", projectIds)
+        .execute()
+
+      appCount = apps.length
+
+      if (apps.length > 0) {
+        const appIds = apps.map((a) => a.id)
+        const deployments = await db
+          .selectFrom("deployments")
+          .select(["app_id", "status", "created_at"])
+          .where("app_id", "in", appIds)
+          .orderBy("created_at", "desc")
+          .execute()
+
+        const latestByApp = new Map<string, string>()
+        for (const d of deployments) {
+          if (!latestByApp.has(d.app_id)) latestByApp.set(d.app_id, d.status)
+        }
+
+        const inFlight = new Set(["building", "scanning", "pending_deployment", "deploying"])
+        const appNameById = new Map(apps.map((a) => [a.id, a.name]))
+        for (const [appId, status] of latestByApp) {
+          if (inFlight.has(status)) inFlightAppNames.push(appNameById.get(appId) ?? appId)
+        }
+      }
+    }
+
+    personalTeamImpact = { projectCount: projects.length, appCount, inFlightAppNames }
+  }
+
+  return {
+    personalTeam: personalTeamImpact,
+    sharedTeamsReowned: sharedTeams.map((t) => t.name),
+  }
+}
+
 export async function deleteUser(
   db: DB,
   id: string,
-  requesterId: string
+  requesterId: string,
+  options: { force?: boolean } = {}
 ): Promise<boolean> {
   if (id === requesterId) {
     throw new ServiceError("Cannot delete your own account", "FORBIDDEN", 403)
   }
-  // Block deletion if the user owns any team — admin must delete the team first.
-  const ownedTeam = await db
-    .selectFrom("teams")
-    .select("name")
+
+  // Reassign ownership of shared teams to the requesting admin — owner_id carries
+  // no access-control meaning on non-personal teams, it's just metadata.
+  await db
+    .updateTable("teams")
+    .set({ owner_id: requesterId, updated_at: new Date().toISOString() })
     .where("owner_id", "=", id)
-    .limit(1)
+    .where("is_personal", "=", false)
+    .execute()
+
+  const personalTeam = await db
+    .selectFrom("teams")
+    .select(["id"])
+    .where("owner_id", "=", id)
+    .where("is_personal", "=", true)
     .executeTakeFirst()
-  if (ownedTeam) {
-    throw new ServiceError(
-      `Cannot delete this user: they own the team "${ownedTeam.name}". Delete or transfer ownership of the team first.`,
-      "CONFLICT",
-      409
-    )
+
+  if (personalTeam) {
+    const projects = await db
+      .selectFrom("projects")
+      .select(["id", "slug"])
+      .where("team_id", "=", personalTeam.id)
+      .execute()
+
+    if (projects.length > 0) {
+      if (!options.force) {
+        const n = projects.length
+        throw new ServiceError(
+          `User has ${n} project${n === 1 ? "" : "s"}. Use force deletion to remove everything.`,
+          "CONFLICT",
+          409
+        )
+      }
+
+      const projectIds = projects.map((p) => p.id)
+      const apps = await db
+        .selectFrom("apps")
+        .select(["id", "name"])
+        .where("project_id", "in", projectIds)
+        .execute()
+
+      if (apps.length > 0) {
+        const appIds = apps.map((a) => a.id)
+        const deployments = await db
+          .selectFrom("deployments")
+          .select(["app_id", "status", "created_at"])
+          .where("app_id", "in", appIds)
+          .orderBy("created_at", "desc")
+          .execute()
+
+        const latestByApp = new Map<string, string>()
+        for (const d of deployments) {
+          if (!latestByApp.has(d.app_id)) latestByApp.set(d.app_id, d.status)
+        }
+
+        const inFlight = new Set(["building", "scanning", "pending_deployment", "deploying"])
+        const blocked = apps.filter((a) => {
+          const s = latestByApp.get(a.id)
+          return s !== undefined && inFlight.has(s)
+        })
+        if (blocked.length > 0) {
+          const names = blocked.map((a) => a.name).join(", ")
+          throw new ServiceError(
+            `Cannot delete: ${blocked.length} app${blocked.length === 1 ? " is" : "s are"} actively building or deploying (${names}). Stop them first.`,
+            "CONFLICT",
+            409
+          )
+        }
+
+        const now = new Date().toISOString()
+
+        // Stop live deployments so the controller can tear down K8s resources.
+        await db
+          .updateTable("deployments")
+          .set({ status: "stopped", error_message: null, updated_at: now })
+          .where("app_id", "in", appIds)
+          .where("status", "=", "live")
+          .execute()
+
+        await db
+          .updateTable("apps")
+          .set({ live_url: null })
+          .where("id", "in", appIds)
+          .execute()
+      }
+
+      // Queue namespace deletions before removing project records.
+      const now = new Date().toISOString()
+      for (const project of projects) {
+        const ns = appNamespace(project.id, project.slug)
+        await db
+          .insertInto("pending_namespace_deletions")
+          .values({ id: crypto.randomUUID(), namespace: ns, created_at: now })
+          .onConflict((oc) => oc.doNothing())
+          .execute()
+      }
+
+      // Delete projects; apps/deployments/etc cascade.
+      await db.deleteFrom("projects").where("id", "in", projectIds).execute()
+    }
+
+    await db.deleteFrom("team_members").where("team_id", "=", personalTeam.id).execute()
+    await db.deleteFrom("teams").where("id", "=", personalTeam.id).execute()
   }
-  const result = await db
-    .deleteFrom("user")
-    .where("id", "=", id)
-    .executeTakeFirst()
+
+  const result = await db.deleteFrom("user").where("id", "=", id).executeTakeFirst()
   return (result.numDeletedRows ?? 0n) > 0n
+}
+
+// ── Team member management (admin-scoped, no membership check) ────────────────
+
+export async function getTeamMembersForAdmin(db: DB, teamId: string): Promise<TeamMember[] | null> {
+  const team = await db.selectFrom("teams").select("id").where("id", "=", teamId).executeTakeFirst()
+  if (!team) return null
+  const rows = await db
+    .selectFrom("team_members as tm")
+    .innerJoin("user as u", "u.id", "tm.user_id")
+    .select(["tm.user_id", "tm.created_at", "u.name", "u.email", "u.image"])
+    .where("tm.team_id", "=", teamId)
+    .orderBy("tm.created_at", "asc")
+    .execute()
+  return rows.map((r) => ({
+    userId: r.user_id,
+    name: r.name,
+    email: r.email,
+    image: r.image ?? undefined,
+    joinedAt: r.created_at,
+  }))
 }
 
 // ── Overview ──────────────────────────────────────────────────────────────────

--- a/apps/api/src/services/app-logs.ts
+++ b/apps/api/src/services/app-logs.ts
@@ -1,8 +1,8 @@
 import type { DB } from "../db/db"
+import { appNamespace } from "../utils/k8s"
 
 // getAppNamespace returns the Kubernetes namespace components needed to proxy log streams.
 // Returns null if the user does not have access to the app.
-// The namespace format must match AppNamespace() in apps/controller/internal/k8s/resources.go.
 export async function getAppNamespace(
   db: DB,
   appId: string,
@@ -22,10 +22,9 @@ export async function getAppNamespace(
     .executeTakeFirst()
   if (!row) return null
 
-  const slug = row.project_slug.length > 50 ? row.project_slug.slice(0, 50) : row.project_slug
   return {
     appSlug: row.app_slug,
-    namespace: `can-${row.project_id.slice(0, 8)}-${slug}`,
+    namespace: appNamespace(row.project_id, row.project_slug),
   }
 }
 

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -4,6 +4,7 @@ import type { Selectable, Updateable } from "kysely"
 import type { Database } from "../db/types"
 import { sql } from "kysely"
 import { ServiceError } from "./errors"
+import { appNamespace } from "../utils/k8s"
 import { isTeamMember } from "./membership"
 
 // ── Internal row type (snake_case, never exported) ────────────────────────────
@@ -196,7 +197,7 @@ export async function updateProject(
   }
 
   if (slugChanging) {
-    const oldNamespace = `can-${projectId.slice(0, 7)}-${project.slug.slice(0, 50)}`
+    const oldNamespace = appNamespace(projectId, project.slug)
     await db
       .updateTable("deployments")
       .set({ applied_manifest: null })

--- a/apps/api/src/utils/k8s.ts
+++ b/apps/api/src/utils/k8s.ts
@@ -1,0 +1,5 @@
+// appNamespace returns the Kubernetes namespace for a project.
+// Must stay in sync with AppNamespace() in apps/controller/internal/k8s/resources.go.
+export function appNamespace(projectId: string, projectSlug: string): string {
+  return `can-${projectId.slice(0, 8)}-${projectSlug.slice(0, 50)}`
+}

--- a/apps/ui/src/app/(authenticated)/admin/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/page.tsx
@@ -9,11 +9,12 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/component
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
+import { Checkbox } from "@/components/ui/checkbox"
 import { ChevronDown, Copy, Check } from "lucide-react"
 import { useSession } from "@/lib/auth-client"
 import { AppShell } from "@/components/app-shell"
 import * as api from "@/lib/api"
-import type { AdminProjectOverview, AdminTeamOverview, ResourceDefaults, ScanPolicy, SyncResult, User, WebhookSettings } from "@canette/types"
+import type { AdminProjectOverview, AdminTeamOverview, ResourceDefaults, ScanPolicy, SyncResult, TeamMember, User, UserDeletionImpact, WebhookSettings } from "@canette/types"
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -73,10 +74,22 @@ export default function AdminPage() {
   // per-project expansion in overview
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set())
 
+  // team member management
+  const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set())
+  const [teamMembers, setTeamMembers] = useState<Map<string, TeamMember[]>>(new Map())
+  const [teamMembersLoading, setTeamMembersLoading] = useState<Set<string>>(new Set())
+  const [addMemberTeamId, setAddMemberTeamId] = useState<string | null>(null)
+  const [addMemberEmail, setAddMemberEmail] = useState("")
+  const [addingMember, setAddingMember] = useState(false)
+  const [addMemberError, setAddMemberError] = useState("")
+
   // user actions
   const [actionError, setActionError] = useState("")
   const [pendingAction, setPendingAction] = useState<string | null>(null) // user id being acted on
   const [deleteConfirm, setDeleteConfirm] = useState<User | null>(null)
+  const [deletionImpact, setDeletionImpact] = useState<UserDeletionImpact | null>(null)
+  const [deletionImpactLoading, setDeletionImpactLoading] = useState(false)
+  const [deleteImpactAcknowledged, setDeleteImpactAcknowledged] = useState(false)
   const [roleToggleConfirm, setRoleToggleConfirm] = useState<User | null>(null)
   const [resetPasswordConfirm, setResetPasswordConfirm] = useState<User | null>(null)
   const [resetPasswordPending, setResetPasswordPending] = useState<string | null>(null)
@@ -121,12 +134,34 @@ export default function AdminPage() {
     }
   }
 
-  async function handleDelete(userId: string) {
+  async function openDeleteConfirm(user: User) {
+    setDeleteConfirm(user)
+    setDeletionImpact(null)
+    setDeleteImpactAcknowledged(false)
+    setDeletionImpactLoading(true)
+    try {
+      const impact = await api.admin.getUserDeletionImpact(user.id)
+      setDeletionImpact(impact)
+    } catch {
+      // impact fetch failed — we'll still show the dialog, delete may fail with a clear error
+    } finally {
+      setDeletionImpactLoading(false)
+    }
+  }
+
+  async function handleDelete(userId: string, force: boolean) {
     setActionError("")
     setPendingAction(userId)
     try {
-      await api.admin.deleteUser(userId)
+      await api.admin.deleteUser(userId, force)
       setUsers((prev) => prev.filter((u) => u.id !== userId))
+      setTeamMembers((prev) => {
+        const next = new Map(prev)
+        for (const [teamId, members] of next) {
+          next.set(teamId, members.filter((m) => m.userId !== userId))
+        }
+        return next
+      })
       setDeleteConfirm(null)
     } catch (e: unknown) {
       setActionError(e instanceof Error ? e.message : "Failed to delete user")
@@ -204,6 +239,56 @@ export default function AdminPage() {
       if (next.has(id)) next.delete(id); else next.add(id)
       return next
     })
+  }
+
+  async function toggleTeam(teamId: string) {
+    setExpandedTeams((prev) => {
+      const next = new Set(prev)
+      if (next.has(teamId)) { next.delete(teamId); return next }
+      next.add(teamId)
+      return next
+    })
+    if (!teamMembers.has(teamId)) {
+      setTeamMembersLoading((prev) => new Set(prev).add(teamId))
+      try {
+        const members = await api.admin.getTeamMembers(teamId)
+        setTeamMembers((prev) => new Map(prev).set(teamId, members))
+      } finally {
+        setTeamMembersLoading((prev) => { const next = new Set(prev); next.delete(teamId); return next })
+      }
+    }
+  }
+
+  async function handleAdminAddMember(e: React.FormEvent, teamId: string) {
+    e.preventDefault()
+    if (!addMemberEmail.trim()) return
+    setAddMemberError("")
+    setAddingMember(true)
+    try {
+      await api.teams.addMember(teamId, { email: addMemberEmail.trim() })
+      setAddMemberEmail("")
+      setAddMemberTeamId(null)
+      const members = await api.admin.getTeamMembers(teamId)
+      setTeamMembers((prev) => new Map(prev).set(teamId, members))
+      setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: members.length } : t))
+    } catch (e: unknown) {
+      setAddMemberError(e instanceof Error ? e.message : "Failed to add member")
+    } finally {
+      setAddingMember(false)
+    }
+  }
+
+  async function handleAdminRemoveMember(teamId: string, userId: string) {
+    try {
+      await api.teams.removeMember(teamId, userId)
+      setTeamMembers((prev) => {
+        const updated = (prev.get(teamId) ?? []).filter((m) => m.userId !== userId)
+        return new Map(prev).set(teamId, updated)
+      })
+      setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: t.memberCount - 1 } : t))
+    } catch {
+      // ignore
+    }
   }
 
   const currentUserId = typeof session?.user?.id === "string" ? session.user.id : undefined
@@ -285,7 +370,7 @@ export default function AdminPage() {
                                 size="sm"
                                 variant="ghost"
                                 className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
-                                onClick={() => setDeleteConfirm(user)}
+                                onClick={() => openDeleteConfirm(user)}
                                 disabled={pendingAction === user.id || resetPasswordPending === user.id}
                               >
                                 Delete
@@ -318,28 +403,98 @@ export default function AdminPage() {
                 {adminTeams.length === 0 ? (
                   <p className="text-muted-foreground text-sm px-6 pb-4">No teams yet.</p>
                 ) : (
-                  <>
-                    <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
-                      <span className="text-xs text-muted-foreground uppercase flex-1">Name</span>
-                      <span className="text-xs text-muted-foreground uppercase w-20 text-right">Members</span>
-                      <span className="text-xs text-muted-foreground uppercase w-20 text-right">Projects</span>
-                    </div>
-                    {adminTeams.map((team, i) => (
+                  adminTeams.map((team, i) => {
+                    const expanded = expandedTeams.has(team.id)
+                    const members = teamMembers.get(team.id)
+                    const membersLoading = teamMembersLoading.has(team.id)
+                    return (
                       <div key={team.id}>
                         {i > 0 && <Separator />}
-                        <div className="flex items-center gap-4 px-6 py-3">
+                        <button
+                          type="button"
+                          className="w-full flex items-center gap-4 px-6 py-3 hover:bg-muted/40 transition-colors text-left"
+                          onClick={() => toggleTeam(team.id)}
+                        >
                           <div className="flex items-center gap-2 flex-1 min-w-0">
                             <span className="text-sm font-medium truncate">{team.name}</span>
                             {team.isPersonal && (
                               <Badge variant="secondary" className="text-xs font-normal shrink-0">personal</Badge>
                             )}
                           </div>
-                          <span className="text-xs text-muted-foreground w-20 text-right">{team.memberCount}</span>
-                          <span className="text-xs text-muted-foreground w-20 text-right">{team.projectCount}</span>
-                        </div>
+                          <span className="text-xs text-muted-foreground w-16 text-right">{team.memberCount} member{team.memberCount !== 1 ? "s" : ""}</span>
+                          <span className="text-xs text-muted-foreground w-20 text-right">{team.projectCount} project{team.projectCount !== 1 ? "s" : ""}</span>
+                          <Chevron open={expanded} />
+                        </button>
+                        {expanded && (
+                          <div className="border-t border-border/50 bg-muted/20">
+                            {membersLoading && (
+                              <p className="text-xs text-muted-foreground px-10 py-3">Loading…</p>
+                            )}
+                            {!membersLoading && members && members.length > 0 && (
+                              members.map((member, j) => (
+                                <div key={member.userId}>
+                                  {j > 0 && <Separator />}
+                                  <div className="flex items-center gap-3 pl-10 pr-6 py-2.5 group">
+                                    <div className="flex-1 min-w-0">
+                                      <p className="text-sm truncate">{member.name}</p>
+                                      <p className="text-xs text-muted-foreground truncate">{member.email}</p>
+                                    </div>
+                                    {!team.isPersonal && (
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 shrink-0"
+                                        onClick={() => handleAdminRemoveMember(team.id, member.userId)}
+                                        title="Remove member"
+                                      >
+                                        ×
+                                      </Button>
+                                    )}
+                                  </div>
+                                </div>
+                              ))
+                            )}
+                            {!membersLoading && members && members.length === 0 && (
+                              <p className="text-xs text-muted-foreground pl-10 pr-6 py-2.5">No members.</p>
+                            )}
+                            {!team.isPersonal && (
+                              <div className="pl-10 pr-6 py-3 border-t border-border/50">
+                                {addMemberTeamId === team.id ? (
+                                  <form onSubmit={(e) => handleAdminAddMember(e, team.id)} className="flex flex-col gap-2">
+                                    <div className="flex gap-2 items-center">
+                                      <input
+                                        type="email"
+                                        placeholder="user@example.com"
+                                        value={addMemberEmail}
+                                        onChange={(e) => setAddMemberEmail(e.target.value)}
+                                        className="h-8 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                                        autoFocus
+                                      />
+                                      <Button type="submit" size="sm" className="h-8" disabled={!addMemberEmail.trim() || addingMember}>
+                                        {addingMember ? "Adding…" : "Add"}
+                                      </Button>
+                                      <Button type="button" size="sm" variant="ghost" className="h-8" onClick={() => { setAddMemberTeamId(null); setAddMemberEmail(""); setAddMemberError("") }}>
+                                        Cancel
+                                      </Button>
+                                    </div>
+                                    {addMemberError && <p className="text-xs text-destructive">{addMemberError}</p>}
+                                  </form>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                                    onClick={() => { setAddMemberTeamId(team.id); setAddMemberEmail(""); setAddMemberError("") }}
+                                  >
+                                    + Add member
+                                  </button>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
-                    ))}
-                  </>
+                    )
+                  })
                 )}
                 <div className="px-6 py-3 border-t border-border/50">
                   <Link href="/dashboard/teams/new" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
@@ -685,22 +840,61 @@ export default function AdminPage() {
       </Dialog>
 
       {/* Confirm before deleting a user */}
-      <Dialog open={deleteConfirm !== null} onOpenChange={(open) => { if (!open) setDeleteConfirm(null) }}>
+      <Dialog open={deleteConfirm !== null} onOpenChange={(open) => { if (!open) { setDeleteConfirm(null); setDeletionImpact(null); setDeleteImpactAcknowledged(false) } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete user?</DialogTitle>
-            <DialogDescription>
-              This will permanently delete <strong>{deleteConfirm?.name}</strong> ({deleteConfirm?.email}) and all their data. This cannot be undone.
+            <DialogDescription asChild>
+              <div>
+                <span>Permanently delete <strong>{deleteConfirm?.name}</strong> ({deleteConfirm?.email}).</span>
+                {deletionImpactLoading && (
+                  <span className="block mt-2 text-xs text-muted-foreground">Checking account data…</span>
+                )}
+                {!deletionImpactLoading && deletionImpact && (
+                  <>
+                    {deletionImpact.sharedTeamsReowned.length > 0 && (
+                      <span className="block mt-2 text-xs text-muted-foreground">
+                        Ownership of {deletionImpact.sharedTeamsReowned.length === 1 ? "team" : "teams"} <strong>{deletionImpact.sharedTeamsReowned.join(", ")}</strong> will be transferred to you.
+                      </span>
+                    )}
+                    {deletionImpact.personalTeam && deletionImpact.personalTeam.inFlightAppNames.length > 0 && (
+                      <span className="block mt-2 text-sm text-destructive">
+                        Cannot delete: {deletionImpact.personalTeam.inFlightAppNames.length === 1 ? "app" : "apps"} <strong>{deletionImpact.personalTeam.inFlightAppNames.join(", ")}</strong> {deletionImpact.personalTeam.inFlightAppNames.length === 1 ? "is" : "are"} currently building or deploying. Stop {deletionImpact.personalTeam.inFlightAppNames.length === 1 ? "it" : "them"} first.
+                      </span>
+                    )}
+                    {deletionImpact.personalTeam && deletionImpact.personalTeam.inFlightAppNames.length === 0 && deletionImpact.personalTeam.projectCount > 0 && (
+                      <span className="block mt-2 text-sm text-amber-600 dark:text-amber-500">
+                        This will permanently delete {deletionImpact.personalTeam.projectCount} project{deletionImpact.personalTeam.projectCount !== 1 ? "s" : ""} and {deletionImpact.personalTeam.appCount} app{deletionImpact.personalTeam.appCount !== 1 ? "s" : ""}. Running apps will be stopped. Kubernetes resources will be cleaned up in the background.
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
             </DialogDescription>
           </DialogHeader>
+          {!deletionImpactLoading && deletionImpact?.personalTeam && deletionImpact.personalTeam.inFlightAppNames.length === 0 && deletionImpact.personalTeam.projectCount > 0 && (
+            <label className="flex items-center gap-2 px-6 text-sm cursor-pointer select-none">
+              <Checkbox
+                checked={deleteImpactAcknowledged}
+                onCheckedChange={(v) => setDeleteImpactAcknowledged(v === true)}
+              />
+              I understand all projects and apps will be permanently deleted
+            </label>
+          )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteConfirm(null)}>Cancel</Button>
+            <Button variant="outline" onClick={() => { setDeleteConfirm(null); setDeletionImpact(null); setDeleteImpactAcknowledged(false) }}>Cancel</Button>
             <Button
               variant="destructive"
-              disabled={pendingAction === deleteConfirm?.id}
+              disabled={
+                pendingAction === deleteConfirm?.id ||
+                deletionImpactLoading ||
+                !!(deletionImpact?.personalTeam?.inFlightAppNames.length) ||
+                !!(deletionImpact?.personalTeam && deletionImpact.personalTeam.projectCount > 0 && !deleteImpactAcknowledged)
+              }
               onClick={() => {
                 if (!deleteConfirm) return
-                handleDelete(deleteConfirm.id)
+                const force = !!(deletionImpact?.personalTeam && deletionImpact.personalTeam.projectCount > 0)
+                handleDelete(deleteConfirm.id, force)
               }}
             >
               {pendingAction === deleteConfirm?.id ? "Deleting…" : "Delete user"}

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/page.tsx
@@ -56,11 +56,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   const [credentials, setCredentials] = useState<GitCredential[]>([])
   const [loading, setLoading] = useState(true)
 
-  // Members
-  const [addEmail, setAddEmail] = useState("")
-  const [addingMember, setAddingMember] = useState(false)
-  const [memberError, setMemberError] = useState("")
-
   // Credentials
   const [credName, setCredName] = useState("")
   const [credProvider, setCredProvider] = useState<GitProvider>("github")
@@ -114,32 +109,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
       setGithubAppNotice("Failed to complete GitHub App installation. Please try again.")
     }
   }, [searchParams, load])
-
-  async function handleAddMember(e: React.FormEvent) {
-    e.preventDefault()
-    if (!addEmail.trim()) return
-    setMemberError("")
-    setAddingMember(true)
-    try {
-      await api.teams.addMember(teamId, { email: addEmail.trim() })
-      setAddEmail("")
-      const teamData = await api.teams.get(teamId)
-      setMembers(teamData.members)
-    } catch (e: unknown) {
-      setMemberError(e instanceof Error ? e.message : "Failed to add member")
-    } finally {
-      setAddingMember(false)
-    }
-  }
-
-  async function handleRemoveMember(userId: string) {
-    try {
-      await api.teams.removeMember(teamId, userId)
-      setMembers((prev) => prev.filter((m) => m.userId !== userId))
-    } catch {
-      // ignore
-    }
-  }
 
   async function handleAddCred(e: React.FormEvent) {
     e.preventDefault()
@@ -308,56 +277,26 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
               <>
                 <div className="px-6 py-1.5 flex items-center gap-4 border-b border-border/50">
                   <span className="text-xs text-muted-foreground uppercase flex-1">Name / Email</span>
-                  <span className="text-xs text-muted-foreground uppercase w-20">Joined</span>
-                  {isAdmin && <span className="w-7" />}
+                  <span className="text-xs text-muted-foreground uppercase text-right w-20">Joined</span>
                 </div>
                 {members.map((member, i) => (
                   <div key={member.userId}>
                     {i > 0 && <Separator />}
-                    <div className="flex items-center gap-4 px-6 py-3 group">
+                    <div className="flex items-center gap-4 px-6 py-3">
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium truncate">{member.name}</p>
                         <p className="text-xs text-muted-foreground truncate">{member.email}</p>
                       </div>
-                      <span className="text-xs text-muted-foreground w-20">{timeAgo(member.joinedAt)}</span>
-                      {isAdmin && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100"
-                          disabled={member.userId === team.ownerId}
-                          title={member.userId === team.ownerId ? "Cannot remove team owner" : "Remove member"}
-                          onClick={() => handleRemoveMember(member.userId)}
-                        >
-                          ×
-                        </Button>
-                      )}
+                      <span className="text-xs text-muted-foreground text-right w-20">{timeAgo(member.joinedAt)}</span>
                     </div>
                   </div>
                 ))}
-                <Separator />
               </>
             )}
-
             {!team.isPersonal && isAdmin && (
-              <form onSubmit={handleAddMember} className="px-6 py-4 flex flex-col gap-3">
-                <div className="flex gap-3 items-end">
-                  <div className="flex flex-col gap-1.5 flex-1">
-                    <Label htmlFor="member-email">Add member by email</Label>
-                    <Input
-                      id="member-email"
-                      type="email"
-                      placeholder="user@example.com"
-                      value={addEmail}
-                      onChange={(e) => setAddEmail(e.target.value)}
-                    />
-                  </div>
-                  <Button type="submit" size="sm" disabled={!addEmail.trim() || addingMember}>
-                    {addingMember ? "Adding…" : "Add"}
-                  </Button>
-                </div>
-                {memberError && <p className="text-sm text-destructive">{memberError}</p>}
-              </form>
+              <p className="text-xs text-muted-foreground px-6 py-3 border-t border-border/50">
+                Manage members in <a href="/admin" className="underline hover:text-foreground">Admin → Teams</a>.
+              </p>
             )}
           </CardContent>
         </Card>

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -2,7 +2,7 @@
 // All requests go through Next.js rewrites → API server.
 // Never call the API directly from the browser with a hardcoded URL.
 
-import type { AdminProjectOverview, AdminTeamOverview, App, AppSecret, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanPolicy, SyncResult, Team, TeamMember, User, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
+import type { AdminProjectOverview, AdminTeamOverview, App, AppSecret, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanPolicy, SyncResult, Team, TeamMember, User, UserDeletionImpact, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
 
 const base = "/api/v1"
 
@@ -156,7 +156,10 @@ export const admin = {
   listUsers: () => request<User[]>("/admin/users"),
   updateUserRole: (id: string, role: UserRole) =>
     request<User>(`/admin/users/${id}`, { method: "PATCH", body: JSON.stringify({ role }) }),
-  deleteUser: (id: string) => request<void>(`/admin/users/${id}`, { method: "DELETE" }),
+  getUserDeletionImpact: (id: string) => request<UserDeletionImpact>(`/admin/users/${id}/deletion-impact`),
+  getTeamMembers: (teamId: string) => request<TeamMember[]>(`/admin/teams/${teamId}/members`),
+  deleteUser: (id: string, force?: boolean) =>
+    request<void>(`/admin/users/${id}`, { method: "DELETE", body: JSON.stringify({ force }) }),
   getOverview: () => request<AdminProjectOverview[]>("/admin/overview"),
   getTeams: () => request<AdminTeamOverview[]>("/admin/teams"),
   sync: () => request<SyncResult>("/admin/sync", { method: "POST" }),

--- a/charts/canette/templates/controller/clusterrole.yaml
+++ b/charts/canette/templates/controller/clusterrole.yaml
@@ -8,7 +8,7 @@ rules:
   # Namespace management — required to create per-project namespaces at runtime
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["create", "get", "patch"]
+    verbs: ["create", "get", "patch", "delete"]
   # App workload resources in dynamically created can-* namespaces
   - apiGroups: ["apps"]
     resources: ["deployments"]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -203,6 +203,15 @@ export interface SyncResult {
   message: string
 }
 
+export interface UserDeletionImpact {
+  personalTeam: {
+    projectCount: number
+    appCount: number
+    inFlightAppNames: string[]
+  } | null
+  sharedTeamsReowned: string[]
+}
+
 // API envelope types
 
 export interface ApiError {


### PR DESCRIPTION
## Force-delete users with projects

This fixes a regression from introducing (personal) teams, breaking user deletion.

Admins can now safely delete users who own projects. The flow:

- **Impact preview** — `GET /api/v1/admin/users/:id/deletion-impact` returns affected project/app counts and any in-flight build names before the admin commits to deletion
- **Forced deletion** — `DELETE /api/v1/admin/users/:id` accepts `{ force: true }` in the body; without it the endpoint returns 409 if the user has projects (existing behaviour preserved for safe default)
- **Graceful shutdown** — live apps are stopped and their K8s namespaces queued for deletion before project records are removed; deletion is blocked while any build/deploy is actively in flight
- Admin UI updated with a confirmation dialog showing the impact summary and a force-delete checkbox

## Namespace name mismatch fix

The API was computing `can-{id[:7]}-{slug}` when queuing namespace deletions, while the controller's `AppNamespace()` uses `id[:8]`. Every queued deletion was silently targeting the wrong namespace, leaving K8s resources running after project or user deletion.

Fixed by extracting the formula into `apps/api/src/utils/k8s.ts:appNamespace()` — a single canonical TypeScript definition with a comment pointing at its Go counterpart in `apps/controller/internal/k8s/resources.go`. All three call-sites (`admin.ts`, `projects.ts`, `app-logs.ts`) now use the util.

## Controller ClusterRole

The controller's service account was missing the `delete` verb on `namespaces`, causing every pending namespace deletion to be forbidden at the Kubernetes API level. Added `delete` to the namespaces rule in `charts/canette/templates/controller/clusterrole.yaml`. Requires `helm upgrade` to take effect.

---

**Minor fixes**
- Admin team members panel no longer shows a deleted user as still being a member after deletion
- Auth: align UUID generation to use `crypto.randomUUID()` directly instead of the `"uuid"` string constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)