### PR TITLE
fix: credential hint, team link, and build error display

### DIFF
--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/[appSlug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/[appSlug]/page.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils"
 import { AppShell } from "@/components/app-shell"
 import { CredentialSelect } from "@/components/credential-select"
 import * as api from "@/lib/api"
-import type { App, AppSecret, BuildLog, Deployment, EnvVar, GitCredential, ScanSummary } from "@canette/types"
+import type { App, AppSecret, BuildLog, Deployment, EnvVar, GitCredential, Project, ScanSummary } from "@canette/types"
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -896,6 +896,7 @@ export default function AppDetailPage() {
   const { slug: projectSlug, appSlug } = useParams<{ slug: string; appSlug: string }>()
   const router = useRouter()
   const [app, setApp] = useState<App | null>(null)
+  const [project, setProject] = useState<Project | null>(null)
   const [deploymentList, setDeploymentList] = useState<Deployment[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
@@ -965,9 +966,11 @@ const [canetteConfigDraft, setCanetteConfigDraft] = useState("")
     Promise.all([
       api.apps.getBySlug(projectSlug, appSlug),
       api.projects.listCredentials(projectSlug).catch(() => [] as GitCredential[]),
+      api.projects.get(projectSlug),
     ])
-      .then(([a, creds]) => {
+      .then(([a, creds, proj]) => {
         setApp(a)
+        setProject(proj)
         setName(a.name)
         setSourceType(a.sourceType)
         setGitUrl(a.gitUrl)
@@ -1165,7 +1168,10 @@ const [canetteConfigDraft, setCanetteConfigDraft] = useState("")
           <CardContent className="flex flex-col gap-3">
             {actionError && <p className="text-sm text-destructive">{actionError}</p>}
             {currentDeployment?.status === "failed" && currentDeployment.errorMessage && (
-              <p className="text-sm text-destructive font-mono">{currentDeployment.errorMessage}</p>
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5">
+                <p className="text-xs font-medium text-destructive mb-1">Build failed</p>
+                <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">{currentDeployment.errorMessage}</p>
+              </div>
             )}
             {liveDeployment && app.liveUrl && (
               <a
@@ -1372,6 +1378,7 @@ const [canetteConfigDraft, setCanetteConfigDraft] = useState("")
                         credentials={credentials}
                         value={gitCredentialId}
                         onChange={setGitCredentialId}
+                        teamId={project?.teamId}
                       />
                     </>
                   ) : (

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/new/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/new/page.tsx
@@ -263,13 +263,12 @@ export default function NewAppPage() {
                     )}
                   </div>
 
-                  {credentials.length > 0 && (
-                    <CredentialSelect
-                      credentials={credentials}
-                      value={gitCredentialId}
-                      onChange={setGitCredentialId}
-                    />
-                  )}
+                  <CredentialSelect
+                    credentials={credentials}
+                    value={gitCredentialId}
+                    onChange={setGitCredentialId}
+                    teamId={project?.teamId}
+                  />
 
                   <div className="grid grid-cols-2 gap-4">
                     <div className="flex flex-col gap-1.5">

--- a/apps/ui/src/app/(authenticated)/dashboard/settings/credentials/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/settings/credentials/page.tsx
@@ -1,6 +1,0 @@
-import { redirect } from "next/navigation"
-
-// Credentials are now managed per-team. Redirect to the teams page.
-export default function CredentialsRedirect() {
-  redirect("/dashboard/teams")
-}

--- a/apps/ui/src/components/credential-select.tsx
+++ b/apps/ui/src/components/credential-select.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -7,10 +8,11 @@ interface Props {
   credentials: GitCredential[]
   value: string        // "" means "no credential"
   onChange: (value: string) => void
+  teamId?: string
   id?: string
 }
 
-export function CredentialSelect({ credentials, value, onChange, id = "gitCredentialId" }: Props) {
+export function CredentialSelect({ credentials, value, onChange, teamId, id = "gitCredentialId" }: Props) {
   return (
     <div className="flex flex-col gap-1.5">
       <Label htmlFor={id}>Credential</Label>
@@ -38,6 +40,18 @@ export function CredentialSelect({ credentials, value, onChange, id = "gitCreden
           ))}
         </SelectContent>
       </Select>
+      {credentials.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          For private repos,{" "}
+          <Link
+            href={teamId ? `/dashboard/teams/${teamId}` : "/dashboard/teams"}
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            add a credential
+          </Link>{" "}
+          first.
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Credential hint**: When no credentials exist, `CredentialSelect` now shows a hint — "For private repos, add a credential first" — with a link directly to the project's team page (`/dashboard/teams/[teamId]`). Previously the whole dropdown was hidden.
- **Credentials redirect page removed**: `/dashboard/settings/credentials/page.tsx` deleted — nothing links there anymore, and the old server-side `redirect()` was causing a \"cannot have a negative time stamp\" performance error anyway.
- **Build error display**: Replaced the raw red monofont `<p>` with a styled callout box (light red border + background, \"Build failed\" label, wrapped muted message text).

## Test plan

- [ ] Create an app in a project whose team has no credentials — confirm hint appears with a working link to the team page
- [ ] Trigger a build that fails — confirm error message renders in the callout box, not as raw red mono text

🤖 Generated with [Claude Code](https://claude.com/claude-code)