### PR TITLE
MCP - Helm deployment fixes

### DIFF
--- a/apps/api/src/services/mcp.ts
+++ b/apps/api/src/services/mcp.ts
@@ -236,7 +236,7 @@ export async function handleTool(name: string, args: Record<string, unknown>, us
 
 export function buildMcpServer(userId: string): Server {
   const server = new Server(
-    { name: "canette", version: "1.0.0" },
+    { name: "canette", version: process.env.APP_VERSION ?? "development" },
     { capabilities: { tools: {} } },
   )
 

--- a/charts/canette/templates/api/deployment.yaml
+++ b/charts/canette/templates/api/deployment.yaml
@@ -132,6 +132,8 @@ spec:
               value: {{ .Values.api.defaultResources.memoryLimit | quote }}
             - name: WEBHOOK_BASE_URL
               value: {{ .Values.api.webhookBaseUrl | quote }}
+            - name: APP_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             - name: DISABLE_EMAIL_SIGNUP
               value: {{ if .Values.api.disableEmailSignup }}"true"{{ else }}"false"{{ end }}
             - name: MCP_JWT_SECRET

--- a/charts/canette/templates/api/secret.yaml
+++ b/charts/canette/templates/api/secret.yaml
@@ -16,7 +16,12 @@
 {{- if .Values.api.mcpJwtSecret }}
   {{- $mcpJwtSecret = .Values.api.mcpJwtSecret }}
 {{- else if $existingSecret }}
-  {{- $mcpJwtSecret = index $existingSecret.data "mcp-jwt-secret" | b64dec }}
+  {{- $existingMcpJwt := index $existingSecret.data "mcp-jwt-secret" }}
+  {{- if $existingMcpJwt }}
+    {{- $mcpJwtSecret = $existingMcpJwt | b64dec }}
+  {{- else }}
+    {{- $mcpJwtSecret = randAlphaNum 64 | sha256sum }}
+  {{- end }}
 {{- else }}
   {{- $mcpJwtSecret = randAlphaNum 64 | sha256sum }}
 {{- end }}

--- a/charts/canette/templates/ui/httproute.yaml
+++ b/charts/canette/templates/ui/httproute.yaml
@@ -29,8 +29,17 @@ spec:
           port: 3001
     - matches:
         - path:
+            type: Exact
+            value: /oauth/token
+        - path:
+            type: Exact
+            value: /oauth/register
+        - path:
+            type: Exact
+            value: /oauth/confirm
+        - path:
             type: PathPrefix
-            value: /oauth
+            value: /oauth/clients
       backendRefs:
         - name: canette-api
           port: 3001


### PR DESCRIPTION
This PR contains a few oversights that should have been included in https://github.com/canette/canette/pull/82

- Main fix is a redirect loop in Authentication when the API and the UI is hosted under the same domain name.