### PR TITLE
feat: external database SSL support and Helm install fixes

### DIFF
--- a/apps/api/src/db/db.ts
+++ b/apps/api/src/db/db.ts
@@ -1,5 +1,6 @@
 import { Pool } from "pg"
 import { Kysely, PostgresDialect } from "kysely"
+import { readFileSync } from "fs"
 import type { Database } from "./types"
 
 export type DB = Kysely<Database>
@@ -8,7 +9,23 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is required")
 }
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+function buildSslConfig(): object | undefined {
+  const caFile = process.env.DATABASE_CA_CERT_FILE
+  const rejectUnauthorized = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== "false"
+
+  if (!caFile && rejectUnauthorized) return undefined
+
+  if (!rejectUnauthorized) {
+    console.warn("DATABASE_SSL_REJECT_UNAUTHORIZED=false: TLS certificate verification is disabled")
+  }
+
+  return {
+    ca: caFile ? readFileSync(caFile, "utf8") : undefined,
+    rejectUnauthorized,
+  }
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: buildSslConfig() })
 
 export const db: DB = new Kysely<Database>({
   dialect: new PostgresDialect({ pool }),

--- a/apps/docs/content/docs/self-hosting/helm.mdx
+++ b/apps/docs/content/docs/self-hosting/helm.mdx
@@ -128,6 +128,7 @@ These values are snapshotted into each deployment at trigger time. Changing them
 | `postgres.enabled` | `true` | Deploy in-cluster PostgreSQL |
 | `postgres.password` | `""` | Override auto-generated postgres password (leave empty to auto-generate) |
 | `externalDatabase.url` | `""` | External DB connection string when `postgres.enabled=false` |
+| `externalDatabase.ssl.rejectUnauthorized` | `true` | Verify the database server's TLS certificate. Set to `false` only for dev/testing — disables MITM protection. |
 | `registry.enabled` | `true` | Deploy in-cluster image registry, exposed via HTTPRoute at `registry.<domain>` |
 | `registry.username` | `""` | Override auto-generated registry username (both fields required to override) |
 | `registry.password` | `""` | Override auto-generated registry password |
@@ -197,6 +198,50 @@ externalDatabase:
 ```
 
 Kubernetes substitutes `$(DB_PASSWORD)` at pod startup.
+
+### External database SSL
+
+Managed databases (AWS RDS, Cloud SQL, Azure Database) use a certificate authority that is not in the default system trust store. Provide the CA certificate so canette can verify the server's TLS certificate.
+
+**Option 1 — reference an existing Secret (recommended):**
+
+Create a Secret containing the PEM-encoded CA bundle, then point `caCertSecretRef` at it:
+
+```bash
+kubectl create secret generic my-db-ca \
+  --namespace canette-system \
+  --from-file=ca.crt=rds-ca-bundle.pem
+```
+
+```yaml
+externalDatabase:
+  url: "postgresql://myuser:$(DB_PASSWORD)@mydb.abc123.us-east-1.rds.amazonaws.com:5432/mydb?sslmode=verify-full"
+  ssl:
+    caCertSecretRef:
+      name: my-db-ca
+      key: ca.crt
+```
+
+**Option 2 — inline PEM in values:**
+
+```yaml
+externalDatabase:
+  ssl:
+    caCert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+```
+
+<Callout type="warn">
+  **Do not use `rejectUnauthorized: false` in production.** This disables certificate verification entirely, leaving the connection vulnerable to man-in-the-middle attacks. It exists only as an escape hatch for local dev or testing against managed cloud databases where you control the network.
+
+  ```yaml
+  externalDatabase:
+    ssl:
+      rejectUnauthorized: false
+  ```
+</Callout>
 
 ### External registry password
 

--- a/apps/docs/content/docs/troubleshooting/build-issues.mdx
+++ b/apps/docs/content/docs/troubleshooting/build-issues.mdx
@@ -1,0 +1,96 @@
+---
+title: Build Issues
+description: Troubleshoot build failures and buildkitd startup problems.
+---
+
+import { Callout } from "fumadocs-ui/components/callout"
+
+## buildkitd fails to start — "no space left on device"
+
+### Symptoms
+
+The `buildkitd` pod in the `canette-system-build` namespace fails to start. The pod logs contain:
+
+```
+[rootlesskit:parent] /proc/sys/user/max_user_namespaces needs to be set to non-zero.
+[rootlesskit:parent] error: failed to start the child: fork/exec /proc/self/exe: no space left on device
+```
+
+Despite the message, this is not a disk space problem.
+
+### Cause
+
+Rootless BuildKit uses Linux user namespaces to run builds without root privileges. Some Linux distributions — including Amazon Linux 2 (the default for older EKS managed node groups) — ship with user namespace creation disabled by setting the kernel parameter `user.max_user_namespaces=0`.
+
+When this limit is zero, any attempt to create a user namespace returns `ENOSPC` ("no space left on device"), which is the misleading error you see above.
+
+### Fix
+
+The parameter needs to be set to a non-zero value on every node that will run buildkitd. A value of `15000` is typical.
+
+**Option 1 — EKS launch template (recommended, persistent)**
+
+Add a userdata script to your EKS managed node group launch template so the setting survives node replacements:
+
+```bash
+#!/bin/bash
+echo 'user.max_user_namespaces=15000' > /etc/sysctl.d/99-user-namespaces.conf
+sysctl -p /etc/sysctl.d/99-user-namespaces.conf
+```
+
+After saving the launch template, trigger a node group rolling update so new nodes pick up the change.
+
+**Option 2 — privileged DaemonSet (no node group changes required)**
+
+If you cannot modify the launch template (e.g. you are using an unmanaged node group or a shared cluster), you can apply the sysctl live with a privileged DaemonSet:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: user-namespaces-sysctl
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: user-namespaces-sysctl
+  template:
+    metadata:
+      labels:
+        app: user-namespaces-sysctl
+    spec:
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: sysctl
+          image: busybox:1.36
+          command: ["sysctl", "-w", "user.max_user_namespaces=15000"]
+          securityContext:
+            privileged: true
+      containers:
+        - name: pause
+          image: busybox:1.36
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+```
+
+<Callout type="info">
+  The DaemonSet sets the sysctl on every node restart via the init container, so it remains effective after node replacements. It is safe to leave running alongside the launch template fix.
+</Callout>
+
+After applying either fix, restart the buildkitd pod:
+
+```bash
+kubectl rollout restart deployment/buildkitd -n canette-system-build
+```
+
+### Not affected
+
+This issue does not affect:
+
+- **EKS with AL2023 nodes** — AL2023 enables user namespaces by default
+- **GKE, AKS, and most managed Kubernetes services** — user namespaces are enabled on their default node images
+- **kind and k3s** — both enable user namespaces by default

--- a/apps/docs/content/docs/troubleshooting/meta.json
+++ b/apps/docs/content/docs/troubleshooting/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Troubleshooting",
-  "pages": ["ui-issues"]
+  "pages": ["ui-issues", "build-issues"]
 }

--- a/charts/canette/templates/api/deployment.yaml
+++ b/charts/canette/templates/api/deployment.yaml
@@ -146,6 +146,14 @@ spec:
                   name: canette-api-secrets
                   key: mcp-jwt-secret
                   {{- end }}
+            {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+            - name: DATABASE_CA_CERT_FILE
+              value: /run/secrets/database-ca-cert
+            {{- end }}
+            {{- if and (not .Values.postgres.enabled) (not .Values.externalDatabase.ssl.rejectUnauthorized) }}
+            - name: DATABASE_SSL_REJECT_UNAUTHORIZED
+              value: "false"
+            {{- end }}
             {{- if .Values.migrations.enabled }}
             - name: RUN_MIGRATIONS
               value: "false"
@@ -165,6 +173,12 @@ spec:
             - name: github-app-private-key
               mountPath: /run/secrets/github-app-private-key
               subPath: key
+              readOnly: true
+            {{- end }}
+            {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+            - name: database-ca-cert
+              mountPath: /run/secrets/database-ca-cert
+              subPath: ca.crt
               readOnly: true
             {{- end }}
           resources:
@@ -189,5 +203,20 @@ spec:
             items:
               - key: github-app-private-key
                 path: key
+            {{- end }}
+        {{- end }}
+        {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+        - name: database-ca-cert
+          secret:
+            {{- if .Values.externalDatabase.ssl.caCertSecretRef.name }}
+            secretName: {{ .Values.externalDatabase.ssl.caCertSecretRef.name }}
+            items:
+              - key: {{ .Values.externalDatabase.ssl.caCertSecretRef.key }}
+                path: ca.crt
+            {{- else }}
+            secretName: canette-api-secrets
+            items:
+              - key: database-ca-cert
+                path: ca.crt
             {{- end }}
         {{- end }}

--- a/charts/canette/templates/api/secret.yaml
+++ b/charts/canette/templates/api/secret.yaml
@@ -44,6 +44,9 @@ stringData:
   google-client-id: {{ .Values.api.googleClientId | quote }}
   google-client-secret: {{ .Values.api.googleClientSecret | quote }}
   {{- end }}
+  {{- if .Values.externalDatabase.ssl.caCert }}
+  database-ca-cert: {{ .Values.externalDatabase.ssl.caCert | quote }}
+  {{- end }}
   {{- if .Values.api.githubApp.appId }}
   github-app-id: {{ .Values.api.githubApp.appId | quote }}
   github-app-installation-id: {{ .Values.api.githubApp.installationId | quote }}

--- a/charts/canette/templates/migrations/job.yaml
+++ b/charts/canette/templates/migrations/job.yaml
@@ -62,4 +62,35 @@ spec:
               {{- else }}
               value: {{ include "canette.databaseURL" . | quote }}
               {{- end }}
+            {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+            - name: DATABASE_CA_CERT_FILE
+              value: /run/secrets/database-ca-cert
+            {{- end }}
+            {{- if and (not .Values.postgres.enabled) (not .Values.externalDatabase.ssl.rejectUnauthorized) }}
+            - name: DATABASE_SSL_REJECT_UNAUTHORIZED
+              value: "false"
+            {{- end }}
+          volumeMounts:
+            {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+            - name: database-ca-cert
+              mountPath: /run/secrets/database-ca-cert
+              subPath: ca.crt
+              readOnly: true
+            {{- end }}
+      volumes:
+        {{- if and (not .Values.postgres.enabled) (or .Values.externalDatabase.ssl.caCert .Values.externalDatabase.ssl.caCertSecretRef.name) }}
+        - name: database-ca-cert
+          secret:
+            {{- if .Values.externalDatabase.ssl.caCertSecretRef.name }}
+            secretName: {{ .Values.externalDatabase.ssl.caCertSecretRef.name }}
+            items:
+              - key: {{ .Values.externalDatabase.ssl.caCertSecretRef.key }}
+                path: ca.crt
+            {{- else }}
+            secretName: canette-api-secrets
+            items:
+              - key: database-ca-cert
+                path: ca.crt
+            {{- end }}
+        {{- end }}
 {{- end }}

--- a/charts/canette/templates/namespaces.yaml
+++ b/charts/canette/templates/namespaces.yaml
@@ -1,13 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Release.Namespace }}
-  labels:
-    {{- include "canette.labels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: {{ include "canette.buildNamespace" . }}
   labels:
     {{- include "canette.labels" . | nindent 4 }}

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -60,6 +60,17 @@ externalDatabase:
   passwordSecretRef:
     name: ""
     key: "password"
+  # SSL settings for external databases (e.g. AWS RDS, Cloud SQL).
+  # Provide caCert (inline PEM) or caCertSecretRef (existing K8s Secret) to
+  # verify the server's TLS certificate.
+  ssl:
+    caCert: ""
+    caCertSecretRef:
+      name: ""
+      key: "ca.crt"
+    # Set to false to skip certificate verification.
+    # WARNING: disables MITM protection — only for dev/testing.
+    rejectUnauthorized: true
 
 # ---------------------------------------------------------------------------
 # External registry credentials (used when registry.enabled=false)


### PR DESCRIPTION
## Summary

- **External DB SSL**: adds `externalDatabase.ssl` Helm values (`caCert`, `caCertSecretRef`, `rejectUnauthorized`) so canette can connect to AWS RDS and other managed databases that use a custom CA. The CA cert is mounted as a volume; the API and migrations job both pick it up via `DATABASE_CA_CERT_FILE`. The `pg` pool in `apps/api` is updated to read these env vars.
- **Helm install fix**: removes the release namespace from `namespaces.yaml` so `helm install --create-namespace` no longer fails with `namespaces "canette-system" already exists` when the namespace was pre-created or left over from a failed install.
- **Docs**: documents the new SSL settings and `passwordSecretRef` pattern in `self-hosting/helm.mdx`, and adds a new `troubleshooting/build-issues.mdx` page covering the buildkitd `user.max_user_namespaces=0` failure on EKS AL2 nodes with both the launch template fix and a DaemonSet workaround.

## Test plan

- [ ] `helm template` with `externalDatabase.ssl.caCertSecretRef.name` set renders `DATABASE_CA_CERT_FILE` env var, volumeMount, and volume in the API deployment and migrations job
- [ ] `helm template` with `externalDatabase.ssl.rejectUnauthorized=false` renders `DATABASE_SSL_REJECT_UNAUTHORIZED=false`
- [ ] `helm install --create-namespace` into a pre-existing namespace succeeds
- [ ] API connects to an RDS instance with `sslmode=verify-full` and the CA cert mounted
- [ ] Docs pages render correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)