### PR TITLE
fix: explicit SSL return paths in db pool and expand external DB docs

### DIFF
--- a/apps/api/src/db/db.ts
+++ b/apps/api/src/db/db.ts
@@ -17,11 +17,12 @@ function buildSslConfig(): object | undefined {
 
   if (!rejectUnauthorized) {
     console.warn("DATABASE_SSL_REJECT_UNAUTHORIZED=false: TLS certificate verification is disabled")
+    return { rejectUnauthorized: false }
   }
 
   return {
-    ca: caFile ? readFileSync(caFile, "utf8") : undefined,
-    rejectUnauthorized,
+    ca: readFileSync(caFile!, "utf8"),
+    rejectUnauthorized: true,
   }
 }
 

--- a/apps/docs/content/docs/self-hosting/helm.mdx
+++ b/apps/docs/content/docs/self-hosting/helm.mdx
@@ -197,7 +197,15 @@ externalDatabase:
     key: password
 ```
 
-Kubernetes substitutes `$(DB_PASSWORD)` at pod startup.
+Kubernetes substitutes `$(DB_PASSWORD)` at pod startup. Create the secret before running `helm install` or `helm upgrade`:
+
+```bash
+kubectl create secret generic my-db-secret \
+  --namespace canette-system \
+  --from-literal=password=<your-db-password>
+```
+
+See [Production setup](/docs/getting-started/production) for a full walkthrough of using an external database.
 
 ### External database SSL
 
@@ -241,6 +249,17 @@ externalDatabase:
     ssl:
       rejectUnauthorized: false
   ```
+</Callout>
+
+<Callout type="warn">
+  **Last resort — disable SSL entirely.** If the database server does not require SSL at all, you can turn it off via the connection string. This sends credentials and data in plaintext and must never be used in production.
+
+  ```yaml
+  externalDatabase:
+    url: "postgresql://myuser:mypassword@myhost:5432/mydb?sslmode=disable"
+  ```
+
+  No `ssl` values are needed when SSL is disabled in the connection string — `sslmode=disable` is handled entirely by the `pg` driver.
 </Callout>
 
 ### External registry password


### PR DESCRIPTION
Follow-up to #88.

## Summary

- **`apps/api/src/db/db.ts`**: make `buildSslConfig` return paths explicit so `pg` never receives `ca: undefined`. The `rejectUnauthorized: false` path now returns immediately without attempting to read a CA file.
- **`apps/docs/content/docs/self-hosting/helm.mdx`**: add a `kubectl create secret` example to the `passwordSecretRef` section, and add a `sslmode=disable` last-resort callout to the SSL section.

## Test plan

- [ ] API connects to RDS with `sslmode=verify-full` and a CA cert mounted
- [ ] `DATABASE_SSL_REJECT_UNAUTHORIZED=false` skips cert check without touching `DATABASE_CA_CERT_FILE`
- [ ] Docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)