### PR TITLE
fix(docs): work around fumadocs-core 16.8.5 type regression in createRelativeLink

### DIFF
--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -36,7 +36,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
         <MDX
           components={getMDXComponents({
             // this allows you to link to other pages with relative file paths
-            a: createRelativeLink(source, page),
+            a: createRelativeLink(source as any, page),
           })}
         />
       </DocsBody>


### PR DESCRIPTION
## Summary

- `fumadocs-mdx@14.3.2` narrowed `DocCollectionEntry`'s type in a way that makes the inferred `source` type no longer satisfy `C extends LoaderConfig` in `createRelativeLink`, due to TypeScript's strict function parameter contravariance
- Fixes the docs build failure in dependabot PR #87
- Cast `source as any` at the call site — the function signature itself is unchanged, this is purely a library type issue

## Test plan

- [ ] Docs build passes in CI
- [ ] Merge this, then rebase dependabot PR #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)