### PR TITLE
feat(buildkit): add rooted mode fallback for clusters without user namespace support

### DIFF
--- a/apps/docs/content/docs/security/build-security.mdx
+++ b/apps/docs/content/docs/security/build-security.mdx
@@ -93,7 +93,11 @@ canette builds and deploys whatever the build produces. It does not scan images 
 
 ### Shared `buildkitd`
 
-All builds share a single `buildkitd` daemon. Build cache is shared between builds. A build that intentionally or accidentally corrupts the BuildKit cache could affect subsequent builds. The `buildkitd` pod itself runs with elevated privileges (required for rootless mode) — it is a high-value target and should not be exposed outside the cluster.
+All builds share a single `buildkitd` daemon. Build cache is shared between builds. A build that intentionally or accidentally corrupts the BuildKit cache could affect subsequent builds. The `buildkitd` pod is a high-value target and should not be exposed outside the cluster.
+
+**Rootless mode (default):** buildkitd runs as UID 1000 with `seccompProfile: Unconfined` and `appArmorProfile: Unconfined` — these are required for rootlesskit to set up user and mount namespaces. The pod does not have host privileges.
+
+**Rooted mode (`buildkit.rootless: false`):** buildkitd runs as root with `privileged: true`. This is required on nodes that cannot support user namespaces (e.g. EKS Bottlerocket with SELinux enforcing). It is less secure than rootless — a container escape from buildkitd would have full host access. Only use rooted mode when rootless is not supported by the cluster.
 
 ---
 

--- a/apps/docs/content/docs/self-hosting/aws.mdx
+++ b/apps/docs/content/docs/self-hosting/aws.mdx
@@ -29,7 +29,31 @@ Create a wildcard record in Route 53 pointing `*.apps.example.com` at the ALB's 
 
 ## Node groups and build jobs
 
-Rootless BuildKit requires user namespace support. On EKS, AL2023 nodes support this out of the box. For AL2 nodes, you may need to configure `user.max_user_namespaces` via a launch template userdata script.
+### AL2023 and AL2
+
+Rootless BuildKit requires user namespace support. AL2023 nodes support this out of the box. For AL2 nodes, configure `user.max_user_namespaces` via a launch template userdata script:
+
+```bash
+echo "user.max_user_namespaces=28633" >> /etc/sysctl.d/99-user-ns.conf
+sysctl -p /etc/sysctl.d/99-user-ns.conf
+```
+
+### Bottlerocket
+
+Bottlerocket uses SELinux in enforcing mode. The default SELinux policy blocks the mount namespace operations that rootlesskit requires, even though user namespaces are available at the kernel level. The rootless buildkitd pod will fail to start on Bottlerocket nodes.
+
+Use rooted mode instead by setting `buildkit.rootless: false`:
+
+```yaml
+buildkit:
+  rootless: false
+```
+
+This runs buildkitd as root with `privileged: true`. Privileged containers receive the `spc_t` SELinux label on Bottlerocket, which bypasses the SELinux policy. No other node-level configuration is needed.
+
+<Callout type="warn">
+  Rooted mode requires the `{system}-build` namespace to permit `privileged: true` pods. If your cluster enforces the `Restricted` Pod Security Standard cluster-wide, add a namespace-level exemption for the build namespace before installing canette.
+</Callout>
 
 ## Values
 

--- a/apps/docs/content/docs/self-hosting/helm.mdx
+++ b/apps/docs/content/docs/self-hosting/helm.mdx
@@ -143,6 +143,15 @@ These values are snapshotted into each deployment at trigger time. Changing them
 | `controller.gateway.name` | `can-gateway` | Gateway resource name |
 | `controller.gateway.namespace` | `kube-system` | Gateway resource namespace |
 
+### BuildKit
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `buildkit.rootless` | `true` | Run buildkitd in rootless mode. Requires user namespace support on build nodes. Set to `false` on nodes that cannot support user namespaces (e.g. EKS Bottlerocket). |
+| `buildkit.image` | derived | Override the buildkitd image. When empty, defaults to `moby/buildkit:v0.21.0-rootless` when `rootless=true`, or `moby/buildkit:v0.21.0` when `rootless=false`. |
+| `buildkit.registries` | `{}` | Additional registry trust entries for buildkitd. The in-cluster registry is added automatically. Format: `"host:port": { http: true, insecure: true }` |
+| `buildkit.restrictEgress` | `true` | Block RFC-1918 egress from the build namespace. Prevents a compromised build from reaching cluster-internal services while allowing internet access for package fetches. |
+
 ## Registry authentication
 
 ### In-cluster registry

--- a/apps/docs/content/docs/self-hosting/requirements.mdx
+++ b/apps/docs/content/docs/self-hosting/requirements.mdx
@@ -17,13 +17,36 @@ import { Callout } from "fumadocs-ui/components/callout"
 
 ## Node requirements for builds
 
-Build jobs run rootless BuildKit. Each node that runs builds needs:
+canette builds images using BuildKit. By default it runs in **rootless mode**, which requires user namespace support on each build node. If your nodes cannot meet these requirements, see [rooted mode](#rooted-mode-fallback) below.
+
+### Rootless mode (default)
 
 | Distribution | Requirement |
 |---|---|
 | Ubuntu 24.04+ | `kernel.apparmor_restrict_unprivileged_userns=0` |
 | RHEL / CentOS | `user.max_user_namespaces=28633` |
 | All | Kernel ≥ 4.18 (5.11+ recommended for native overlayfs) |
+
+### Rooted mode fallback
+
+Some node configurations cannot support rootless BuildKit:
+
+- **EKS Bottlerocket** — uses SELinux enforcing mode; the SELinux policy blocks the mount namespace operations that rootlesskit requires, even when user namespaces are available at the kernel level.
+- Clusters running with the `Restricted` Pod Security Standard in the build namespace.
+- Nodes with kernel < 4.18 or `user.max_user_namespaces=0` that cannot be reconfigured.
+
+In these cases, set `buildkit.rootless: false` in your Helm values. This runs buildkitd as root with `privileged: true`, which bypasses the user namespace requirement entirely:
+
+```yaml
+buildkit:
+  rootless: false
+```
+
+No node-level configuration is needed in rooted mode. The `privileged: true` container gets the `spc_t` SELinux label on SELinux nodes, which bypasses policy restrictions.
+
+<Callout type="warn">
+  Rooted mode is less secure than rootless — the buildkitd pod runs with full host privileges. Ensure the `{system}-build` namespace has appropriate RBAC and network policies, and that the buildkitd pod is not reachable from outside the cluster.
+</Callout>
 
 ## Container registry
 

--- a/charts/canette/templates/_helpers.tpl
+++ b/charts/canette/templates/_helpers.tpl
@@ -121,3 +121,16 @@ registry.{{ required "domain is required" .Values.domain }}/
 tcp://buildkitd.{{ include "canette.buildNamespace" . }}.svc.cluster.local:1234
 {{- end -}}
 {{- end }}
+
+{{/* Resolve the buildkitd image.
+     Uses buildkit.image when set; otherwise defaults to the rootless or standard
+     moby/buildkit image based on buildkit.rootless. */}}
+{{- define "canette.buildkitImage" -}}
+{{- if .Values.buildkit.image -}}
+{{ .Values.buildkit.image }}
+{{- else if .Values.buildkit.rootless -}}
+moby/buildkit:v0.21.0-rootless
+{{- else -}}
+moby/buildkit:v0.21.0
+{{- end -}}
+{{- end }}

--- a/charts/canette/templates/buildkit/deployment.yaml
+++ b/charts/canette/templates/buildkit/deployment.yaml
@@ -16,32 +16,44 @@ spec:
       labels:
         app.kubernetes.io/name: buildkitd
     spec:
+      {{- if .Values.buildkit.rootless }}
       securityContext:
         seccompProfile:
           type: Unconfined
         appArmorProfile:
           type: Unconfined
         fsGroup: 1000
+      {{- else }}
+      securityContext:
+        fsGroup: 1000
+      {{- end }}
       containers:
         - name: buildkitd
-          image: {{ .Values.buildkit.image }}
-          imagePullPolicy: {{ include "canette.imagePullPolicy" .Values.buildkit.image }}
+          image: {{ include "canette.buildkitImage" . }}
+          imagePullPolicy: {{ include "canette.imagePullPolicy" (include "canette.buildkitImage" .) }}
           args:
             - --addr
             - tcp://0.0.0.0:1234
+            {{- if .Values.buildkit.rootless }}
             - --oci-worker-no-process-sandbox
+            {{- end }}
             - --config
             - /etc/buildkit/buildkitd.toml
           ports:
             - containerPort: 1234
+          {{- if .Values.buildkit.rootless }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
               type: Unconfined
+          {{- else }}
+          securityContext:
+            privileged: true
+          {{- end }}
           volumeMounts:
             - name: buildkit-state
-              mountPath: /home/user/.local/share/buildkit
+              mountPath: {{ if .Values.buildkit.rootless }}/home/user/.local/share/buildkit{{ else }}/var/lib/buildkit{{ end }}
             - name: buildkitd-config
               mountPath: /etc/buildkit
               readOnly: true

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -117,7 +117,15 @@ registry:
 # BuildKit daemon (always deployed — required by the builder)
 # ---------------------------------------------------------------------------
 buildkit:
-  image: moby/buildkit:v0.21.0-rootless
+  # Run buildkitd in rootless mode (default). Requires user namespace support on the
+  # node — see docs/self-hosting/requirements for per-distro instructions.
+  # Set to false on nodes that do not support user namespaces (e.g. EKS Bottlerocket,
+  # clusters with a restricted kernel). Rooted mode runs buildkitd with privileged: true
+  # instead, which is less secure but works on any node.
+  rootless: true
+  # Override the buildkitd image. When empty, auto-derives to moby/buildkit:v0.21.0-rootless
+  # when rootless=true, or moby/buildkit:v0.21.0 when rootless=false.
+  image: ""
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
## Summary

- Adds `buildkit.rootless` Helm value (default `true`) to switch buildkitd between rootless and rooted (`privileged: true`) mode
- In rooted mode the deployment drops `seccompProfile: Unconfined`, `appArmorProfile: Unconfined`, `runAsNonRoot`, and `--oci-worker-no-process-sandbox`; uses `privileged: true` and mounts state at `/var/lib/buildkit` instead
- Adds `canette.buildkitImage` helper to auto-derive the correct moby/buildkit image tag (`-rootless` suffix or not) based on the flag; `buildkit.image` still overrides both
- Fixes duplicate `buildkit:` key in `labs/values-development.yaml` that was silently discarding `rootless: false`

## Why

Some node configurations cannot run rootless BuildKit:
- **EKS Bottlerocket** — SELinux enforcing mode blocks the mount namespace operations rootlesskit needs, even when user namespaces are available at the kernel level
- Clusters with the `Restricted` Pod Security Standard or `user.max_user_namespaces=0`

## Docs

- `requirements.mdx` — split node requirements into rootless and rooted sections; Bottlerocket called out explicitly
- `aws.mdx` — dedicated Bottlerocket subsection with the fix and a PSA callout
- `helm.mdx` — new BuildKit section in the key values reference
- `build-security.mdx` — updated shared buildkitd risk entry to describe both privilege models

## Usage

```yaml
# values.yaml — for EKS Bottlerocket or any cluster without user namespace support
buildkit:
  rootless: false
```

No other configuration needed. The correct image variant and security context are derived automatically.

## Test plan

- [ ] `helm template` with `buildkit.rootless=true` (default) renders unchanged security context
- [ ] `helm template` with `buildkit.rootless=false` renders `privileged: true`, no seccomp/AppArmor, correct mount path and image
- [ ] `helm lint` passes
- [ ] Deploy with `rootless: false` on a Bottlerocket EKS node and verify buildkitd starts and builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)