### PR TITLE
feat: support imagePullSecret for deployment from the internal or an external registry

### DIFF
--- a/apps/controller/internal/controller/controller.go
+++ b/apps/controller/internal/controller/controller.go
@@ -16,13 +16,16 @@ import (
 
 // Config holds operator-level configuration.
 type Config struct {
-	PullRepo         string // NodePort-accessible registry for kubelet image pulls, e.g. "registry.192-168-64-2.traefik.me:32500/"
-	GatewayName      string
-	GatewayNamespace string
-	ClusterDomain    string
-	Namespace        string // canette-build (build job namespace, not app namespace)
-	PollInterval     time.Duration
-	MaxConcurrent    int
+	PullRepo                string // NodePort-accessible registry for kubelet image pulls, e.g. "registry.192-168-64-2.traefik.me:32500/"
+	GatewayName             string
+	GatewayNamespace        string
+	ClusterDomain           string
+	Namespace               string        // canette-build (build job namespace, not app namespace)
+	PollInterval            time.Duration
+	MaxConcurrent           int
+	ImagePullSecretsEnabled bool   // Enable automatic imagePullSecret creation in app namespaces
+	RegistryAuthConfigFile  string // Path to mounted .dockerconfigjson file
+	RegistryHost            string // Registry host extracted from PullRepo (e.g., "registry.example.com")
 }
 
 // Controller polls for deploying deployments and reconciles them.
@@ -133,7 +136,7 @@ func (c *Controller) processPending(ctx context.Context) error {
 }
 
 // buildDeployConfig translates store+config into k8s.DeployConfig.
-func (c *Controller) buildDeployConfig(cfg *store.AppConfig, secretData map[string][]byte) k8sres.DeployConfig {
+func (c *Controller) buildDeployConfig(cfg *store.AppConfig, secretData map[string][]byte, imagePullSecretName string, imagePullSecretData []byte) k8sres.DeployConfig {
 	var imageRef string
 	if cfg.SourceType == "image" {
 		// image_digest holds the full external image reference (e.g. "nginx:latest")
@@ -148,23 +151,25 @@ func (c *Controller) buildDeployConfig(cfg *store.AppConfig, secretData map[stri
 	}
 
 	return k8sres.DeployConfig{
-		ProjectID:        cfg.ProjectID,
-		ProjectSlug:      cfg.ProjectSlug,
-		ProjectOwner:     cfg.ProjectOwner,
-		AppSlug:          cfg.AppSlug,
-		ImageRef:         imageRef,
-		Port:             cfg.Port,
-		Replicas:         cfg.Replicas,
+		ProjectID:           cfg.ProjectID,
+		ProjectSlug:         cfg.ProjectSlug,
+		ProjectOwner:        cfg.ProjectOwner,
+		AppSlug:             cfg.AppSlug,
+		ImageRef:            imageRef,
+		Port:                cfg.Port,
+		Replicas:            cfg.Replicas,
 		Resources: k8sres.Resources{
 			CPURequest:    cfg.Resources.CPURequest,
 			MemoryRequest: cfg.Resources.MemoryRequest,
 			CPULimit:      cfg.Resources.CPULimit,
 			MemoryLimit:   cfg.Resources.MemoryLimit,
 		},
-		EnvVars:          envMap,
-		SecretData:       secretData,
-		GatewayName:      c.cfg.GatewayName,
-		GatewayNamespace: c.cfg.GatewayNamespace,
-		ClusterDomain:    c.cfg.ClusterDomain,
+		EnvVars:             envMap,
+		SecretData:          secretData,
+		GatewayName:         c.cfg.GatewayName,
+		GatewayNamespace:    c.cfg.GatewayNamespace,
+		ClusterDomain:       c.cfg.ClusterDomain,
+		ImagePullSecretName: imagePullSecretName,
+		ImagePullSecretData: imagePullSecretData,
 	}
 }

--- a/apps/controller/internal/controller/reconcile.go
+++ b/apps/controller/internal/controller/reconcile.go
@@ -65,14 +65,11 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 		// Determine if we need registry credentials based on image source
 		needsRegistryCreds := false
 
-		if appCfg.SourceType == "git" {
-			// Git-sourced apps always use the configured registry (internal or external)
+		switch appCfg.SourceType {
+		case "git":
 			needsRegistryCreds = true
-		} else if appCfg.SourceType == "image" {
-			// Image-sourced apps: check if image URL matches our registry host
-			if strings.HasPrefix(appCfg.ImageDigest, c.cfg.RegistryHost) {
-				needsRegistryCreds = true
-			}
+		case "image":
+			needsRegistryCreds = strings.HasPrefix(appCfg.ImageDigest, c.cfg.RegistryHost)
 		}
 
 		if needsRegistryCreds {

--- a/apps/controller/internal/controller/reconcile.go
+++ b/apps/controller/internal/controller/reconcile.go
@@ -2,7 +2,10 @@ package controller
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -55,11 +58,44 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 		secretData[sec.Key] = []byte(decrypted)
 	}
 
-	// 3. Build K8s resources.
-	deployCfg := c.buildDeployConfig(appCfg, secretData)
+	// 3. Fetch imagePullSecret data if enabled.
+	var imagePullSecretName string
+	var imagePullSecretData []byte
+
+	if c.cfg.ImagePullSecretsEnabled && c.cfg.RegistryAuthConfigFile != "" {
+		// Determine if we need registry credentials based on image source
+		needsRegistryCreds := false
+
+		if appCfg.SourceType == "git" {
+			// Git-sourced apps always use the configured registry (internal or external)
+			needsRegistryCreds = true
+		} else if appCfg.SourceType == "image" {
+			// Image-sourced apps: check if image URL matches our registry host
+			if strings.HasPrefix(appCfg.ImageDigest, c.cfg.RegistryHost) {
+				needsRegistryCreds = true
+			}
+		}
+
+		if needsRegistryCreds {
+			// Read the registry auth config from mounted file
+			dockerConfigJSON, err := os.ReadFile(c.cfg.RegistryAuthConfigFile)
+			if err != nil {
+				log.Warn("failed to read registry auth config file", zap.Error(err))
+				// Non-fatal: continue without imagePullSecret (might still work if nodes have access)
+			} else {
+				imagePullSecretName = "canette-registry-creds"
+				// Base64-encode the JSON for the K8s Secret data field
+				imagePullSecretData = []byte(base64.StdEncoding.EncodeToString(dockerConfigJSON))
+				log.Debug("imagePullSecret enabled", zap.String("secret_name", imagePullSecretName))
+			}
+		}
+	}
+
+	// 4. Build K8s resources.
+	deployCfg := c.buildDeployConfig(appCfg, secretData, imagePullSecretName, imagePullSecretData)
 	res := k8sres.BuildResources(deployCfg)
 
-	// 4. Render and store manifest (before applying — preserves intent even if apply fails).
+	// 5. Render and store manifest (before applying — preserves intent even if apply fails).
 	manifest, err := k8sres.RenderManifest(res)
 	if err != nil {
 		log.Warn("failed to render manifest", zap.Error(err))
@@ -69,7 +105,7 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 		}
 	}
 
-	// 5. Apply all resources via server-side apply.
+	// 6. Apply all resources via server-side apply.
 	// Before applying, clear any pods stuck in ImagePullBackOff/ErrImagePull/CrashLoopBackOff
 	// so K8s recreates them without exponential backoff on the new spec.
 	appNS := k8sres.AppNamespace(dep.ProjectID, dep.ProjectSlug)
@@ -87,7 +123,7 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 	}
 	c.appendLog(ctx, log, dep.ID, "controller", "Resources applied successfully")
 
-	// 6. Watch rollout (poll every 3s, timeout 12min).
+	// 7. Watch rollout (poll every 3s, timeout 12min).
 	// K8s progressDeadlineSeconds defaults to 600s (10min); our timeout must exceed that
 	// so we see the real ProgressDeadlineExceeded condition rather than timing out first.
 	deadline := time.Now().Add(12 * time.Minute)
@@ -120,7 +156,7 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 		return
 	}
 
-	// 7. Mark live and set URL.
+	// 8. Mark live and set URL.
 	if err := c.store.MarkLive(ctx, dep.ID); err != nil {
 		lastErr = fmt.Errorf("mark live: %w", err)
 		return

--- a/apps/controller/internal/controller/reconcile.go
+++ b/apps/controller/internal/controller/reconcile.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -84,8 +83,7 @@ func (c *Controller) reconcile(ctx context.Context, dep store.DeployingDeploymen
 				// Non-fatal: continue without imagePullSecret (might still work if nodes have access)
 			} else {
 				imagePullSecretName = "canette-registry-creds"
-				// Base64-encode the JSON for the K8s Secret data field
-				imagePullSecretData = []byte(base64.StdEncoding.EncodeToString(dockerConfigJSON))
+				imagePullSecretData = dockerConfigJSON
 				log.Debug("imagePullSecret enabled", zap.String("secret_name", imagePullSecretName))
 			}
 		}

--- a/apps/controller/internal/k8s/apply.go
+++ b/apps/controller/internal/k8s/apply.go
@@ -53,7 +53,7 @@ func ApplyResource(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupV
 	return nil
 }
 
-// ApplyAll applies Namespace first, then Secret, Deployment, Service, HTTPRoute.
+// ApplyAll applies Namespace first, then Secrets (env + imagePull), then Deployment, Service, HTTPRoute.
 func ApplyAll(ctx context.Context, dyn dynamic.Interface, res AppResources) error {
 	ns, _ := objectName(res.Namespace)
 	nsNamespace := "" // cluster-scoped
@@ -64,6 +64,11 @@ func ApplyAll(ctx context.Context, dyn dynamic.Interface, res AppResources) erro
 	if res.Secret != nil {
 		if err := ApplyResource(ctx, dyn, gvrSecret, ns, res.Secret); err != nil {
 			return fmt.Errorf("apply secret: %w", err)
+		}
+	}
+	if res.ImagePullSecret != nil {
+		if err := ApplyResource(ctx, dyn, gvrSecret, ns, res.ImagePullSecret); err != nil {
+			return fmt.Errorf("apply imagepullsecret: %w", err)
 		}
 	}
 	if err := ApplyResource(ctx, dyn, gvrDeployment, ns, res.Deployment); err != nil {

--- a/apps/controller/internal/k8s/resources.go
+++ b/apps/controller/internal/k8s/resources.go
@@ -39,7 +39,7 @@ type DeployConfig struct {
 	GatewayNamespace    string
 	ClusterDomain       string
 	ImagePullSecretName string // Name of the imagePullSecret to reference in pod spec
-	ImagePullSecretData []byte // .dockerconfigjson content (base64-encoded) for creating the Secret
+	ImagePullSecretData []byte // raw .dockerconfigjson content; Go's JSON marshaler base64-encodes []byte in data fields
 }
 
 // AppNamespace returns the K8s namespace for a project: can-{id[:8]}-{slug[:50]}.
@@ -118,7 +118,7 @@ func BuildResources(cfg DeployConfig) AppResources {
 			},
 			"type": "kubernetes.io/dockerconfigjson",
 			"data": map[string]interface{}{
-				".dockerconfigjson": cfg.ImagePullSecretData, // Already base64-encoded
+				".dockerconfigjson": cfg.ImagePullSecretData,
 			},
 		}
 	}

--- a/apps/controller/internal/k8s/resources.go
+++ b/apps/controller/internal/k8s/resources.go
@@ -7,11 +7,12 @@ import (
 
 // AppResources holds all K8s objects needed to deploy one app.
 type AppResources struct {
-	Namespace  map[string]interface{}
-	Secret     map[string]interface{} // nil when no secrets
-	Deployment map[string]interface{}
-	Service    map[string]interface{}
-	HTTPRoute  map[string]interface{}
+	Namespace       map[string]interface{}
+	Secret          map[string]interface{} // nil when no secrets
+	ImagePullSecret map[string]interface{} // nil when imagePullSecrets not enabled
+	Deployment      map[string]interface{}
+	Service         map[string]interface{}
+	HTTPRoute       map[string]interface{}
 }
 
 // Resources holds resolved Kubernetes resource requests and limits.
@@ -24,19 +25,21 @@ type Resources struct {
 
 // DeployConfig carries everything needed to build resources.
 type DeployConfig struct {
-	ProjectID        string
-	ProjectSlug      string
-	ProjectOwner     string // user ID who created the project (may be empty)
-	AppSlug          string
-	ImageRef         string // full image reference including digest, e.g. "registry/proj/app@sha256:..."
-	Port             int
-	Replicas         int
-	Resources        Resources
-	EnvVars          map[string]string // plain-text env vars
-	SecretData       map[string][]byte // decrypted secret values
-	GatewayName      string
-	GatewayNamespace string
-	ClusterDomain    string
+	ProjectID           string
+	ProjectSlug         string
+	ProjectOwner        string            // user ID who created the project (may be empty)
+	AppSlug             string
+	ImageRef            string            // full image reference including digest, e.g. "registry/proj/app@sha256:..."
+	Port                int
+	Replicas            int
+	Resources           Resources
+	EnvVars             map[string]string // plain-text env vars
+	SecretData          map[string][]byte // decrypted secret values
+	GatewayName         string
+	GatewayNamespace    string
+	ClusterDomain       string
+	ImagePullSecretName string // Name of the imagePullSecret to reference in pod spec
+	ImagePullSecretData []byte // .dockerconfigjson content (base64-encoded) for creating the Secret
 }
 
 // AppNamespace returns the K8s namespace for a project: can-{id[:8]}-{slug[:50]}.
@@ -102,6 +105,24 @@ func BuildResources(cfg DeployConfig) AppResources {
 		}
 	}
 
+	// Create imagePullSecret if enabled and credentials exist
+	var imagePullSecret map[string]interface{}
+	if cfg.ImagePullSecretName != "" && len(cfg.ImagePullSecretData) > 0 {
+		imagePullSecret = map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      cfg.ImagePullSecretName,
+				"namespace": ns,
+				"labels":    labels,
+			},
+			"type": "kubernetes.io/dockerconfigjson",
+			"data": map[string]interface{}{
+				".dockerconfigjson": cfg.ImagePullSecretData, // Already base64-encoded
+			},
+		}
+	}
+
 	port := cfg.Port
 	if port == 0 {
 		port = 3000
@@ -151,6 +172,13 @@ func BuildResources(cfg DeployConfig) AppResources {
 					"name": secretName(cfg.AppSlug),
 				},
 			},
+		}
+	}
+
+	// Add imagePullSecrets if configured
+	if cfg.ImagePullSecretName != "" {
+		podSpec["imagePullSecrets"] = []interface{}{
+			map[string]interface{}{"name": cfg.ImagePullSecretName},
 		}
 	}
 
@@ -235,10 +263,11 @@ func BuildResources(cfg DeployConfig) AppResources {
 	}
 
 	return AppResources{
-		Namespace:  namespace,
-		Secret:     secretObj,
-		Deployment: deployment,
-		Service:    service,
-		HTTPRoute:  httpRoute,
+		Namespace:       namespace,
+		Secret:          secretObj,
+		ImagePullSecret: imagePullSecret,
+		Deployment:      deployment,
+		Service:         service,
+		HTTPRoute:       httpRoute,
 	}
 }

--- a/apps/controller/main.go
+++ b/apps/controller/main.go
@@ -112,14 +112,27 @@ func run(log *zap.Logger) error {
 		return err
 	}
 
+	// Extract registry host from pullRepo for imagePullSecret matching
+	// e.g., "registry.example.com/" → "registry.example.com"
+	registryHost := strings.TrimSuffix(pullRepo, "/")
+	if idx := strings.Index(registryHost, "/"); idx != -1 {
+		registryHost = registryHost[:idx]
+	}
+
+	imagePullSecretsEnabled := envOr("IMAGE_PULL_SECRETS_ENABLED", "true") == "true"
+	registryAuthConfigFile := envOr("REGISTRY_AUTH_CONFIG_FILE", "")
+
 	cfg := controller.Config{
-		PullRepo:         pullRepo,
-		GatewayName:      envOr("GATEWAY_NAME", "can-gateway"),
-		GatewayNamespace: envOr("GATEWAY_NAMESPACE", "kube-system"),
-		ClusterDomain:    clusterDomain,
-		Namespace:        envOr("BUILDER_NAMESPACE", "canette-build"),
-		PollInterval:     pollInterval,
-		MaxConcurrent:    maxConcurrent,
+		PullRepo:                pullRepo,
+		GatewayName:             envOr("GATEWAY_NAME", "can-gateway"),
+		GatewayNamespace:        envOr("GATEWAY_NAMESPACE", "kube-system"),
+		ClusterDomain:           clusterDomain,
+		Namespace:               envOr("BUILDER_NAMESPACE", "canette-build"),
+		PollInterval:            pollInterval,
+		MaxConcurrent:           maxConcurrent,
+		ImagePullSecretsEnabled: imagePullSecretsEnabled,
+		RegistryAuthConfigFile:  registryAuthConfigFile,
+		RegistryHost:            registryHost,
 	}
 
 	// ── Run ───────────────────────────────────────────────────────────────────

--- a/apps/docs/content/docs/security/platform-security.mdx
+++ b/apps/docs/content/docs/security/platform-security.mdx
@@ -19,6 +19,17 @@ App secrets are encrypted before they are written to the database and decrypted 
 - **Never returned**: the API does not return secret values after they have been stored — not in list responses, not in detail responses, not in logs
 - **Never logged**: secret values are excluded from structured logging at every log level
 
+### Registry pull credentials
+
+When `controller.imagePullSecrets.enabled=true`, the controller creates a `canette-registry-creds` Secret in every app namespace so the kubelet can pull images. This Secret is in the same namespace as the app workload.
+
+**Trade-offs to be aware of:**
+
+- Any pod that gains Kubernetes API access and secret-read RBAC in its namespace can read the pull credential. canette does not grant this by default, but a misconfigured role in the app namespace would expose it.
+- For the in-cluster registry, pull and push credentials are the same — a leaked pull secret therefore grants write access to the registry. For external registries, configure `externalRegistry.pullUsername`/`pullPassword` with a read-only account to scope the credential to pulls only.
+
+The safest configuration is to provision registry access at the node level (containerd credential provider or `/etc/containerd/certs.d/`) and set `controller.imagePullSecrets.enabled=false`. This removes the Secret from app namespaces entirely. See [Image pull credentials](/docs/self-hosting/registry#image-pull-credentials) for setup details.
+
 ### Git credentials (PAT tokens and SSH keys)
 
 Git credentials (PAT tokens and SSH private keys) use the same AES-256-GCM encryption as app secrets. The master key is the same shared key. Credentials are scoped to a project; apps within the project inherit them.

--- a/apps/docs/content/docs/self-hosting/registry.mdx
+++ b/apps/docs/content/docs/self-hosting/registry.mdx
@@ -31,6 +31,51 @@ Registry credentials are auto-generated on first install and reused on every upg
 
 To rotate credentials or set your own, see the [Helm reference](/docs/self-hosting/helm#registry-authentication).
 
+## Image pull credentials
+
+When `controller.imagePullSecrets.enabled=true` (the default), the controller creates a `canette-registry-creds` Secret in each app namespace and references it in the pod spec so the kubelet can pull images.
+
+### In-cluster registry
+
+The internal registry is accessed at two different addresses depending on who is talking to it:
+
+| Caller | Address used |
+|--------|-------------|
+| BuildKit (push) | `registry.canette-system.svc.cluster.local:5000` — HTTP, cluster-internal |
+| Kubelet (pull) | `registry.{domain}` — HTTPS, through the Gateway |
+
+The pull credential placed in app namespaces uses the external pull address as its auth key, so containerd can match it to the image reference.
+
+### External registry — separate pull credentials
+
+For external registries it is good practice to configure a read-only registry account for pulls, separate from the read-write account used by the builder. This limits the blast radius if a pull secret is ever read from an app namespace.
+
+```yaml
+externalRegistry:
+  username: "builder-rw"        # push — used by build jobs
+  password: "..."
+  pullUsername: "puller-ro"     # pull — distributed to app namespaces
+  pullPassword: "..."
+```
+
+`pullUsername`/`pullPassword` fall back to the push credentials when not set. A `pullPasswordSecretRef` is also supported if you prefer to keep the password out of `values.yaml`.
+
+### Disabling imagePullSecrets
+
+If your nodes already have registry access configured at the containerd level (via `/etc/containerd/certs.d/` or a node credential provider), you can disable Secret-based pull credentials entirely:
+
+```yaml
+controller:
+  imagePullSecrets:
+    enabled: false
+```
+
+No `canette-registry-creds` Secret is created and no `imagePullSecrets` field is added to pod specs. This is the recommended approach for production clusters where node-level credentials are managed by the platform team.
+
+<Callout type="warn">
+  **Security note:** When imagePullSecrets are enabled, the pull credential Secret lives in the same namespace as the app. Any pod with Kubernetes API access and secret-read RBAC could read it. canette does not grant this permission to app workloads by default, but a misconfigured role in the app namespace could expose it. For the in-cluster registry, push and pull credentials are identical — a leaked secret therefore grants write access to the registry. See [Platform security](/docs/security/platform-security#registry-pull-credentials) for the full trade-off.
+</Callout>
+
 ## TLS for local development (mkcert)
 
 On a local cluster (k3s, kind, etc.) without a public IP, [Let's Encrypt](/docs/getting-started/installation#1-gateway-api-with-tls-termination) won't work. [mkcert](https://github.com/FiloSottile/mkcert) generates locally-trusted certificates backed by a CA you install yourself.

--- a/charts/canette/templates/_helpers.tpl
+++ b/charts/canette/templates/_helpers.tpl
@@ -76,7 +76,7 @@ https://{{ required "ui.hostname is required" .Values.ui.hostname }}
 {{- end }}
 
 {{/* Resolve the registry host:port (no trailing slash or path segment).
-     Used as the key in .dockerconfigjson. */}}
+     Used as the key in .dockerconfigjson for push credentials (build jobs). */}}
 {{- define "canette.registryHost" -}}
 {{- if .Values.registry.enabled -}}
 registry.{{ .Release.Namespace }}.svc.cluster.local:5000
@@ -85,11 +85,18 @@ registry.{{ .Release.Namespace }}.svc.cluster.local:5000
 {{- end -}}
 {{- end }}
 
+{{/* Resolve the registry host:port as seen by the kubelet (pull hostname).
+     For the in-cluster registry this is the external domain, not the internal service name.
+     Used as the key in .dockerconfigjson for pull credentials (app imagePullSecrets). */}}
+{{- define "canette.registryPullHost" -}}
+{{- include "canette.pullRepo" . | trimSuffix "/" | regexFind "^[^/]+" -}}
+{{- end }}
+
 {{/* Name of the docker config Secret given to build jobs, or empty if no credentials. */}}
 {{- define "canette.registryAuthSecretName" -}}
 {{- if .Values.registry.enabled -}}
 canette-registry-auth
-{{- else if and .Values.externalRegistry.username .Values.externalRegistry.password -}}
+{{- else if .Values.externalRegistry.username -}}
 canette-registry-auth
 {{- end -}}
 {{- end }}

--- a/charts/canette/templates/_helpers.tpl
+++ b/charts/canette/templates/_helpers.tpl
@@ -134,3 +134,17 @@ moby/buildkit:v0.21.0-rootless
 moby/buildkit:v0.21.0
 {{- end -}}
 {{- end }}
+
+{{/* Whether to enable imagePullSecrets in app Deployments.
+     Defaults to true if not explicitly set. */}}
+{{- define "canette.imagePullSecretsEnabled" -}}
+{{- if hasKey .Values.controller "imagePullSecrets" -}}
+{{- if hasKey .Values.controller.imagePullSecrets "enabled" -}}
+{{ .Values.controller.imagePullSecrets.enabled }}
+{{- else -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/canette/templates/controller/deployment.yaml
+++ b/charts/canette/templates/controller/deployment.yaml
@@ -64,6 +64,12 @@ spec:
               value: {{ .Values.controller.logTailInterval | quote }}
             - name: MAX_CONCURRENT
               value: {{ .Values.controller.maxConcurrent | quote }}
+            - name: IMAGE_PULL_SECRETS_ENABLED
+              value: {{ include "canette.imagePullSecretsEnabled" . | quote }}
+            {{- if and (eq (include "canette.imagePullSecretsEnabled" .) "true") (include "canette.registryAuthSecretName" .) }}
+            - name: REGISTRY_AUTH_CONFIG_FILE
+              value: /run/secrets/registry-auth/config.json
+            {{- end }}
           ports:
             - containerPort: 8082
               name: health
@@ -84,6 +90,11 @@ spec:
               mountPath: /run/secrets/encryption-key
               subPath: key
               readOnly: true
+            {{- if and (eq (include "canette.imagePullSecretsEnabled" .) "true") (include "canette.registryAuthSecretName" .) }}
+            - name: registry-auth
+              mountPath: /run/secrets/registry-auth
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       volumes:
@@ -93,3 +104,11 @@ spec:
             items:
               - key: key
                 path: key
+        {{- if and (eq (include "canette.imagePullSecretsEnabled" .) "true") (include "canette.registryAuthSecretName" .) }}
+        - name: registry-auth
+          secret:
+            secretName: {{ include "canette.registryAuthSecretName" . }}
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+        {{- end }}

--- a/charts/canette/templates/registry/auth-secret.yaml
+++ b/charts/canette/templates/registry/auth-secret.yaml
@@ -18,9 +18,11 @@
   {{- $username = "canette" }}
   {{- $password = randAlphaNum 32 }}
 {{- end }}
-{{- $host := include "canette.registryHost" . }}
+{{- $pushHost := include "canette.registryHost" . }}
+{{- $pullHost := include "canette.registryPullHost" . }}
 {{- $auth := printf "%s:%s" $username $password | b64enc }}
-{{- $dockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $host $auth }}
+{{- $pushDockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $pushHost $auth }}
+{{- $pullDockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $pullHost $auth }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -44,6 +46,20 @@ type: Opaque
 stringData:
   htpasswd: {{ htpasswd $username $password | quote }}
 ---
+{{/* Pull credentials for the controller to distribute as app imagePullSecrets.
+     Uses the external pull hostname so the kubelet can match the image reference. */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: canette-registry-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "canette.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: {{ $pullDockerconfig | quote }}
+---
+{{/* Push credentials for build jobs. Uses the internal cluster hostname. */}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -53,18 +69,43 @@ metadata:
     {{- include "canette.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: {{ $dockerconfig | quote }}
+  .dockerconfigjson: {{ $pushDockerconfig | quote }}
 {{- else if .Values.externalRegistry.username }}
-{{- $extPassword := .Values.externalRegistry.password }}
+{{- /* Resolve push password */}}
+{{- $pushPassword := .Values.externalRegistry.password }}
 {{- if .Values.externalRegistry.passwordSecretRef.name }}
   {{- $pwdSecret := lookup "v1" "Secret" .Release.Namespace .Values.externalRegistry.passwordSecretRef.name }}
   {{- if $pwdSecret }}
-    {{- $extPassword = index $pwdSecret.data .Values.externalRegistry.passwordSecretRef.key | b64dec }}
+    {{- $pushPassword = index $pwdSecret.data .Values.externalRegistry.passwordSecretRef.key | b64dec }}
+  {{- end }}
+{{- end }}
+{{- /* Resolve pull password — falls back to push password when no separate pull creds are set */}}
+{{- $pullUsername := .Values.externalRegistry.pullUsername | default .Values.externalRegistry.username }}
+{{- $pullPassword := .Values.externalRegistry.pullPassword | default $pushPassword }}
+{{- if .Values.externalRegistry.pullPasswordSecretRef.name }}
+  {{- $pwdSecret := lookup "v1" "Secret" .Release.Namespace .Values.externalRegistry.pullPasswordSecretRef.name }}
+  {{- if $pwdSecret }}
+    {{- $pullPassword = index $pwdSecret.data .Values.externalRegistry.pullPasswordSecretRef.key | b64dec }}
   {{- end }}
 {{- end }}
 {{- $host := include "canette.registryHost" . }}
-{{- $auth := printf "%s:%s" .Values.externalRegistry.username $extPassword | b64enc }}
-{{- $dockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $host $auth }}
+{{- $pushAuth := printf "%s:%s" .Values.externalRegistry.username $pushPassword | b64enc }}
+{{- $pullAuth := printf "%s:%s" $pullUsername $pullPassword | b64enc }}
+{{- $pushDockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $host $pushAuth }}
+{{- $pullDockerconfig := printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" $host $pullAuth }}
+{{/* Pull credentials for the controller to distribute as app imagePullSecrets. */}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: canette-registry-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "canette.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: {{ $pullDockerconfig | quote }}
+---
+{{/* Push credentials for build jobs. */}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -74,5 +115,5 @@ metadata:
     {{- include "canette.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: {{ $dockerconfig | quote }}
+  .dockerconfigjson: {{ $pushDockerconfig | quote }}
 {{- end }}

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -198,6 +198,13 @@ controller:
   pollInterval: 5s
   logTailInterval: 10s
   maxConcurrent: 3
+  # Enable automatic creation of imagePullSecrets in app namespaces.
+  # When enabled, the controller copies registry credentials to each app namespace
+  # and adds imagePullSecrets to Deployment pod specs. Required for nodes that do
+  # not have registry access configured via containerd/CRI.
+  # Default: true (always create imagePullSecrets for seamless node pulls)
+  imagePullSecrets:
+    enabled: true
   resources:
     requests:
       cpu: 100m

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -76,13 +76,22 @@ externalDatabase:
 # External registry credentials (used when registry.enabled=false)
 # ---------------------------------------------------------------------------
 externalRegistry:
-  # Credentials for pushing to an external registry.
-  # The builder is given a docker config Secret with these credentials.
+  # Push credentials — used by the builder to push images after a build.
   username: ""
   password: ""
-  # Optional: read the password from a Kubernetes Secret instead of a plain value.
+  # Optional: read the push password from a Kubernetes Secret instead of a plain value.
   # The secret must exist in the system namespace before helm install/upgrade.
   passwordSecretRef:
+    name: ""
+    key: "password"
+  # Pull credentials — used by the kubelet to pull images onto app nodes.
+  # Configure a separate read-only registry account here to limit blast radius if the
+  # imagePullSecret is ever read from an app namespace (see imagePullSecrets below).
+  # When not set, falls back to the push credentials above.
+  pullUsername: ""
+  pullPassword: ""
+  # Optional: read the pull password from a Kubernetes Secret instead of a plain value.
+  pullPasswordSecretRef:
     name: ""
     key: "password"
 
@@ -199,10 +208,21 @@ controller:
   logTailInterval: 10s
   maxConcurrent: 3
   # Enable automatic creation of imagePullSecrets in app namespaces.
-  # When enabled, the controller copies registry credentials to each app namespace
-  # and adds imagePullSecrets to Deployment pod specs. Required for nodes that do
-  # not have registry access configured via containerd/CRI.
-  # Default: true (always create imagePullSecrets for seamless node pulls)
+  # When enabled, the controller creates a canette-registry-creds Secret in each app
+  # namespace and adds imagePullSecrets to Deployment pod specs.
+  #
+  # Security notes:
+  # - The Secret lives in the same namespace as the app. Any pod with Kubernetes API
+  #   access and secret-read RBAC could read it. canette does not grant this by default,
+  #   but misconfigured user workloads may.
+  # - For the in-cluster registry, pull and push credentials are identical — a leaked
+  #   secret therefore grants write access to the registry.
+  # - For external registries, configure externalRegistry.pullUsername/pullPassword with
+  #   a read-only registry account to limit the blast radius.
+  #
+  # Alternative: configure registry credentials directly in containerd on each node
+  # (via /etc/containerd/certs.d/ or a node-level credential provider). When nodes
+  # already have access, set enabled: false to skip Secret creation entirely.
   imagePullSecrets:
     enabled: true
   resources:


### PR DESCRIPTION
## Summary

- canette previously required the admin to configure node access to the container repository used by builds. No other access method was possoble
- this adds support for imagePullSecrets in the created deployment
- the feature is enabled by default as it requires less configuration that node based access. Some security concerns are documented.

## Disabling imagePullSecrets

When nodes have registry access via containerd node credentials, the feature can be disabled entirely:

```yaml
controller:
  imagePullSecrets:
    enabled: false
```

## Documentation

Security trade-offs and configuration options documented in `values.yaml`, `registry.mdx`, and `platform-security.mdx`.

## Test plan

- [ ] `helm upgrade` applies without errors — check `canette-registry-auth` exists in both `canette-system` and `canette-system-build`
- [ ] Deploy an app — `canette-registry-creds` Secret created in app namespace with external pull hostname
- [ ] App pod starts successfully (no `ImagePullBackOff`)
- [ ] Set `controller.imagePullSecrets.enabled: false` — confirm no `canette-registry-creds` Secret is created and pods still pull (requires node-level credentials)