### PR TITLE
Team admin improvements + user picker dialog

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -20,7 +20,7 @@ import {
   updateScanPolicy,
   updateUserRole,
 } from "../services/admin"
-import { listTeamsOverview } from "../services/teams"
+import { listTeamsOverview, renameTeam, createTeam, deleteTeam, addMember, removeMember, findUserByEmail } from "../services/teams"
 import type { ScanPolicy, UserRole } from "@canette/types"
 
 function generatePassword(): string {
@@ -125,6 +125,77 @@ adminRouter.get("/overview", async (c) => {
 adminRouter.get("/teams", async (c) => {
   const teams = await listTeamsOverview(db)
   return c.json(teams)
+})
+
+// Create a shared team
+// POST /api/v1/admin/teams
+adminRouter.post("/teams", async (c) => {
+  const session = c.get("session")
+  const body = await c.req.json<{ name: string }>()
+  try {
+    const team = await createTeam(db, session.user.id, body)
+    return c.json(team, 201)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})
+
+// Delete a team
+// DELETE /api/v1/admin/teams/:id
+adminRouter.delete("/teams/:id", async (c) => {
+  try {
+    await deleteTeam(db, c.req.param("id"))
+    return c.body(null, 204)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})
+
+// Add a member to a team
+// POST /api/v1/admin/teams/:id/members
+adminRouter.post("/teams/:id/members", async (c) => {
+  const body = await c.req.json<{ userId?: string; email?: string }>()
+  try {
+    let targetUserId = body.userId
+    if (!targetUserId && body.email) {
+      const found = await findUserByEmail(db, body.email)
+      if (!found) return c.json({ error: "No user found with that email", code: "NOT_FOUND" }, 404)
+      targetUserId = found.id
+    }
+    if (!targetUserId) return c.json({ error: "userId or email is required", code: "VALIDATION_ERROR" }, 400)
+    await addMember(db, c.req.param("id"), targetUserId)
+    return c.body(null, 204)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})
+
+// Remove a member from a team
+// DELETE /api/v1/admin/teams/:id/members/:userId
+adminRouter.delete("/teams/:id/members/:userId", async (c) => {
+  try {
+    await removeMember(db, c.req.param("id"), c.req.param("userId"))
+    return c.body(null, 204)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})
+
+// Rename any team, including personal teams
+// PATCH /api/v1/admin/teams/:id
+adminRouter.patch("/teams/:id", async (c) => {
+  const body = await c.req.json<{ name: string }>()
+  try {
+    const team = await renameTeam(db, c.req.param("id"), body.name)
+    return c.json(team)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
 })
 
 // Get members of any team (admin, no membership required)

--- a/apps/api/src/routes/teams.ts
+++ b/apps/api/src/routes/teams.ts
@@ -1,20 +1,9 @@
 import { Hono } from "hono"
 import { db } from "../db/db"
 import { requireAuth } from "../middleware/require-auth"
-import { requireAdmin } from "../middleware/require-admin"
 import type { AppEnv } from "../types"
 import { ServiceError } from "../services/errors"
-import {
-  listTeams,
-  getTeam,
-  getTeamMembers,
-  createTeam,
-  renameTeam,
-  deleteTeam,
-  addMember,
-  removeMember,
-  findUserByEmail,
-} from "../services/teams"
+import { listTeams, getTeam, getTeamMembers } from "../services/teams"
 import {
   listTeamCredentials,
   createCredential,
@@ -46,81 +35,6 @@ teamsRouter.get("/:id", async (c) => {
   ])
   if (!team || !members) return c.json({ error: "Not found", code: "NOT_FOUND" }, 404)
   return c.json({ ...team, members })
-})
-
-// Create a team (admin only)
-// POST /api/v1/teams
-teamsRouter.post("/", requireAdmin, async (c) => {
-  const session = c.get("session")
-  const body = await c.req.json<{ name: string }>()
-  try {
-    const team = await createTeam(db, session.user.id, session.user.role, body)
-    return c.json(team, 201)
-  } catch (e) {
-    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
-    throw e
-  }
-})
-
-// Rename a team (admin only)
-// PATCH /api/v1/teams/:id
-teamsRouter.patch("/:id", requireAdmin, async (c) => {
-  const session = c.get("session")
-  const body = await c.req.json<{ name: string }>()
-  try {
-    const team = await renameTeam(db, c.req.param("id"), body.name, session.user.id, session.user.role)
-    return c.json(team)
-  } catch (e) {
-    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
-    throw e
-  }
-})
-
-// Delete a team (admin only)
-// DELETE /api/v1/teams/:id
-teamsRouter.delete("/:id", requireAdmin, async (c) => {
-  const session = c.get("session")
-  try {
-    await deleteTeam(db, c.req.param("id"), session.user.id, session.user.role)
-    return c.body(null, 204)
-  } catch (e) {
-    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
-    throw e
-  }
-})
-
-// Add a member to a team (admin only)
-// POST /api/v1/teams/:id/members
-teamsRouter.post("/:id/members", requireAdmin, async (c) => {
-  const session = c.get("session")
-  const body = await c.req.json<{ userId?: string; email?: string }>()
-  try {
-    let targetUserId = body.userId
-    if (!targetUserId && body.email) {
-      const found = await findUserByEmail(db, body.email)
-      if (!found) return c.json({ error: "No user found with that email", code: "NOT_FOUND" }, 404)
-      targetUserId = found.id
-    }
-    if (!targetUserId) return c.json({ error: "userId or email is required", code: "VALIDATION_ERROR" }, 400)
-    await addMember(db, c.req.param("id"), targetUserId, session.user.id, session.user.role)
-    return c.body(null, 204)
-  } catch (e) {
-    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
-    throw e
-  }
-})
-
-// Remove a member from a team (admin only)
-// DELETE /api/v1/teams/:id/members/:userId
-teamsRouter.delete("/:id/members/:userId", requireAdmin, async (c) => {
-  const session = c.get("session")
-  try {
-    await removeMember(db, c.req.param("id"), c.req.param("userId"), session.user.id, session.user.role)
-    return c.body(null, 204)
-  } catch (e) {
-    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
-    throw e
-  }
 })
 
 // ── Credentials (team-scoped) ─────────────────────────────────────────────────

--- a/apps/api/src/services/teams.ts
+++ b/apps/api/src/services/teams.ts
@@ -108,15 +108,7 @@ export async function getTeamMembers(
   return rows.map(mapTeamMember)
 }
 
-export async function createTeam(
-  db: DB,
-  requesterId: string,
-  requesterRole: string,
-  input: { name: string }
-): Promise<Team> {
-  if (requesterRole !== "admin") {
-    throw new ServiceError("Only admins can create teams", "FORBIDDEN", 403)
-  }
+export async function createTeam(db: DB, ownerId: string, input: { name: string }): Promise<Team> {
   if (!input.name?.trim()) {
     throw new ServiceError("name is required", "VALIDATION_ERROR", 400)
   }
@@ -131,7 +123,7 @@ export async function createTeam(
         id: teamId,
         name: input.name.trim(),
         is_personal: false,
-        owner_id: requesterId,
+        owner_id: ownerId,
         created_at: now,
         updated_at: now,
       })
@@ -141,7 +133,7 @@ export async function createTeam(
       .values({
         id: crypto.randomUUID(),
         team_id: teamId,
-        user_id: requesterId,
+        user_id: ownerId,
         created_at: now,
       })
       .execute()
@@ -155,16 +147,7 @@ export async function createTeam(
   return mapTeam({ ...row, member_count: 1 })
 }
 
-export async function renameTeam(
-  db: DB,
-  teamId: string,
-  name: string,
-  requesterId: string,
-  requesterRole: string
-): Promise<Team> {
-  if (requesterRole !== "admin") {
-    throw new ServiceError("Only admins can rename teams", "FORBIDDEN", 403)
-  }
+export async function renameTeam(db: DB, teamId: string, name: string): Promise<Team> {
   if (!name?.trim()) {
     throw new ServiceError("name is required", "VALIDATION_ERROR", 400)
   }
@@ -175,29 +158,30 @@ export async function renameTeam(
     .where("id", "=", teamId)
     .executeTakeFirst()
   if (!team) throw new ServiceError("Not found", "NOT_FOUND", 404)
-  if (team.is_personal) {
-    throw new ServiceError("Personal teams cannot be renamed", "FORBIDDEN", 403)
-  }
 
+  const now = new Date().toISOString()
   await db
     .updateTable("teams")
-    .set({ name: name.trim(), updated_at: new Date().toISOString() })
+    .set({ name: name.trim(), updated_at: now })
     .where("id", "=", teamId)
     .execute()
 
-  return (await getTeam(db, teamId, requesterId))!
+  const updated = await db
+    .selectFrom("teams as t")
+    .selectAll("t")
+    .select((eb) =>
+      eb
+        .selectFrom("team_members")
+        .select(eb.fn.countAll<number>().as("c"))
+        .whereRef("team_id", "=", "t.id")
+        .as("member_count")
+    )
+    .where("t.id", "=", teamId)
+    .executeTakeFirstOrThrow()
+  return mapTeam(updated)
 }
 
-export async function deleteTeam(
-  db: DB,
-  teamId: string,
-  requesterId: string,
-  requesterRole: string
-): Promise<void> {
-  if (requesterRole !== "admin") {
-    throw new ServiceError("Only admins can delete teams", "FORBIDDEN", 403)
-  }
-
+export async function deleteTeam(db: DB, teamId: string): Promise<void> {
   const team = await db
     .selectFrom("teams")
     .selectAll()
@@ -226,17 +210,7 @@ export async function deleteTeam(
   await db.deleteFrom("teams").where("id", "=", teamId).execute()
 }
 
-export async function addMember(
-  db: DB,
-  teamId: string,
-  targetUserId: string,
-  requesterId: string,
-  requesterRole: string
-): Promise<void> {
-  if (requesterRole !== "admin") {
-    throw new ServiceError("Only admins can add team members", "FORBIDDEN", 403)
-  }
-
+export async function addMember(db: DB, teamId: string, targetUserId: string): Promise<void> {
   const team = await db
     .selectFrom("teams")
     .select("id")
@@ -270,26 +244,39 @@ export async function addMember(
   }
 }
 
-export async function removeMember(
-  db: DB,
-  teamId: string,
-  targetUserId: string,
-  requesterId: string,
-  requesterRole: string
-): Promise<void> {
-  if (requesterRole !== "admin") {
-    throw new ServiceError("Only admins can remove team members", "FORBIDDEN", 403)
-  }
-
+export async function removeMember(db: DB, teamId: string, targetUserId: string): Promise<void> {
   const team = await db
     .selectFrom("teams")
-    .select(["id", "owner_id", "is_personal"])
+    .select(["id", "owner_id"])
     .where("id", "=", teamId)
     .executeTakeFirst()
   if (!team) throw new ServiceError("Team not found", "NOT_FOUND", 404)
 
   if (team.owner_id === targetUserId) {
-    throw new ServiceError("Cannot remove the team owner", "CONFLICT", 409)
+    const next = await db
+      .selectFrom("team_members")
+      .select("user_id")
+      .where("team_id", "=", teamId)
+      .where("user_id", "!=", targetUserId)
+      .orderBy("created_at", "asc")
+      .limit(1)
+      .executeTakeFirst()
+    if (!next) {
+      throw new ServiceError("Cannot remove the only member — delete the team instead", "CONFLICT", 409)
+    }
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("teams")
+        .set({ owner_id: next.user_id, updated_at: new Date().toISOString() })
+        .where("id", "=", teamId)
+        .execute()
+      await trx
+        .deleteFrom("team_members")
+        .where("team_id", "=", teamId)
+        .where("user_id", "=", targetUserId)
+        .execute()
+    })
+    return
   }
 
   await db

--- a/apps/ui/src/app/(authenticated)/admin/teams/new/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/teams/new/page.tsx
@@ -20,7 +20,7 @@ export default function NewTeamPage() {
     setError("")
     setSubmitting(true)
     try {
-      await api.teams.create({ name: name.trim() })
+      await api.admin.createTeam({ name: name.trim() })
       router.push("/admin/teams")
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Something went wrong")

--- a/apps/ui/src/app/(authenticated)/admin/teams/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/teams/page.tsx
@@ -40,6 +40,9 @@ export default function AdminTeamsPage() {
   const [deletingTeam, setDeletingTeam] = useState(false)
   const [deleteTeamError, setDeleteTeamError] = useState("")
 
+  const [removeMemberErrorTeamId, setRemoveMemberErrorTeamId] = useState<string | null>(null)
+  const [removeMemberError, setRemoveMemberError] = useState("")
+
   const [renameTeamTarget, setRenameTeamTarget] = useState<AdminTeamOverview | null>(null)
   const [renameTeamName, setRenameTeamName] = useState("")
   const [renamingTeam, setRenamingTeam] = useState(false)
@@ -76,7 +79,7 @@ export default function AdminTeamsPage() {
     setAddMemberError("")
     setAddingMember(true)
     try {
-      await api.teams.addMember(teamId, { email: addMemberEmail.trim() })
+      await api.admin.addTeamMember(teamId, { email: addMemberEmail.trim() })
       setAddMemberEmail("")
       setAddMemberTeamId(null)
       const members = await api.admin.getTeamMembers(teamId)
@@ -90,15 +93,18 @@ export default function AdminTeamsPage() {
   }
 
   async function handleAdminRemoveMember(teamId: string, userId: string) {
+    setRemoveMemberErrorTeamId(null)
+    setRemoveMemberError("")
     try {
-      await api.teams.removeMember(teamId, userId)
+      await api.admin.removeTeamMember(teamId, userId)
       setTeamMembers((prev) => {
         const updated = (prev.get(teamId) ?? []).filter((m) => m.userId !== userId)
         return new Map(prev).set(teamId, updated)
       })
       setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: t.memberCount - 1 } : t))
-    } catch {
-      // ignore
+    } catch (e: unknown) {
+      setRemoveMemberError(e instanceof Error ? e.message : "Failed to remove member")
+      setRemoveMemberErrorTeamId(teamId)
     }
   }
 
@@ -107,7 +113,7 @@ export default function AdminTeamsPage() {
     setDeleteTeamError("")
     setDeletingTeam(true)
     try {
-      await api.teams.delete(deleteTeamConfirm.id)
+      await api.admin.deleteTeam(deleteTeamConfirm.id)
       setAdminTeams((prev) => prev.filter((t) => t.id !== deleteTeamConfirm.id))
       setDeleteTeamConfirm(null)
     } catch (e: unknown) {
@@ -123,7 +129,7 @@ export default function AdminTeamsPage() {
     setRenameTeamError("")
     setRenamingTeam(true)
     try {
-      await api.teams.rename(renameTeamTarget.id, renameTeamName.trim())
+      await api.admin.renameTeam(renameTeamTarget.id, renameTeamName.trim())
       setAdminTeams((prev) => prev.map((t) => t.id === renameTeamTarget.id ? { ...t, name: renameTeamName.trim() } : t))
       setRenameTeamTarget(null)
     } catch (e: unknown) {
@@ -176,10 +182,13 @@ export default function AdminTeamsPage() {
             {!membersLoading && members && members.length === 0 && (
               <p className="text-xs text-muted-foreground pl-10 pr-6 py-2.5">No members.</p>
             )}
-            {!team.isPersonal && (
-              <div className="pl-10 pr-6 py-2 border-t border-border/50 flex items-center justify-between">
-                <div className="flex-1">
-                  {addMemberTeamId === team.id ? (
+            {removeMemberErrorTeamId === team.id && removeMemberError && (
+              <p className="text-xs text-destructive pl-10 pr-6 py-2">{removeMemberError}</p>
+            )}
+            <div className="pl-10 pr-6 py-2 border-t border-border/50 flex items-center justify-between">
+              <div className="flex-1">
+                {!team.isPersonal && (
+                  addMemberTeamId === team.id ? (
                     <form onSubmit={(e) => handleAdminAddMember(e, team.id)} className="flex flex-col gap-2">
                       <div className="flex gap-2 items-center">
                         <input
@@ -207,16 +216,18 @@ export default function AdminTeamsPage() {
                     >
                       + Add member
                     </button>
-                  )}
-                </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    size="sm" variant="ghost"
-                    className="h-7 text-xs text-muted-foreground hover:text-foreground shrink-0"
-                    onClick={() => { setRenameTeamError(""); setRenameTeamName(team.name); setRenameTeamTarget(team) }}
-                  >
-                    Rename
-                  </Button>
+                  )
+                )}
+              </div>
+              <div className="flex items-center gap-1">
+                <Button
+                  size="sm" variant="ghost"
+                  className="h-7 text-xs text-muted-foreground hover:text-foreground shrink-0"
+                  onClick={() => { setRenameTeamError(""); setRenameTeamName(team.name); setRenameTeamTarget(team) }}
+                >
+                  Rename
+                </Button>
+                {!team.isPersonal && (
                   <Button
                     size="sm" variant="ghost"
                     className="h-7 text-xs text-muted-foreground hover:text-destructive shrink-0"
@@ -224,9 +235,9 @@ export default function AdminTeamsPage() {
                   >
                     Delete team
                   </Button>
-                </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         )}
       </div>

--- a/apps/ui/src/app/(authenticated)/admin/teams/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/teams/page.tsx
@@ -10,6 +10,8 @@ import { Label } from "@/components/ui/label"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { ChevronDown } from "lucide-react"
 import { Skeleton, SkeletonText } from "@/components/ui/skeleton"
+import { UserPickerDialog } from "@/components/user-picker-dialog"
+import { UserAvatar } from "@/components/ui/user-avatar"
 import * as api from "@/lib/api"
 import type { AdminTeamOverview, TeamMember } from "@canette/types"
 
@@ -32,15 +34,13 @@ export default function AdminTeamsPage() {
   const [teamMembersLoading, setTeamMembersLoading] = useState<Set<string>>(new Set())
 
   const [addMemberTeamId, setAddMemberTeamId] = useState<string | null>(null)
-  const [addMemberEmail, setAddMemberEmail] = useState("")
-  const [addingMember, setAddingMember] = useState(false)
-  const [addMemberError, setAddMemberError] = useState("")
 
   const [deleteTeamConfirm, setDeleteTeamConfirm] = useState<AdminTeamOverview | null>(null)
   const [deletingTeam, setDeletingTeam] = useState(false)
   const [deleteTeamError, setDeleteTeamError] = useState("")
 
-  const [removeMemberErrorTeamId, setRemoveMemberErrorTeamId] = useState<string | null>(null)
+  const [removeMemberConfirm, setRemoveMemberConfirm] = useState<{ teamId: string; member: TeamMember } | null>(null)
+  const [removingMember, setRemovingMember] = useState(false)
   const [removeMemberError, setRemoveMemberError] = useState("")
 
   const [renameTeamTarget, setRenameTeamTarget] = useState<AdminTeamOverview | null>(null)
@@ -73,38 +73,29 @@ export default function AdminTeamsPage() {
     }
   }
 
-  async function handleAdminAddMember(e: React.FormEvent, teamId: string) {
-    e.preventDefault()
-    if (!addMemberEmail.trim()) return
-    setAddMemberError("")
-    setAddingMember(true)
-    try {
-      await api.admin.addTeamMember(teamId, { email: addMemberEmail.trim() })
-      setAddMemberEmail("")
-      setAddMemberTeamId(null)
-      const members = await api.admin.getTeamMembers(teamId)
-      setTeamMembers((prev) => new Map(prev).set(teamId, members))
-      setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: members.length } : t))
-    } catch (e: unknown) {
-      setAddMemberError(e instanceof Error ? e.message : "Failed to add member")
-    } finally {
-      setAddingMember(false)
-    }
+  async function handleMemberAdded(teamId: string) {
+    const members = await api.admin.getTeamMembers(teamId)
+    setTeamMembers((prev) => new Map(prev).set(teamId, members))
+    setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: members.length } : t))
   }
 
-  async function handleAdminRemoveMember(teamId: string, userId: string) {
-    setRemoveMemberErrorTeamId(null)
+  async function handleAdminRemoveMember() {
+    if (!removeMemberConfirm) return
+    const { teamId, member } = removeMemberConfirm
     setRemoveMemberError("")
+    setRemovingMember(true)
     try {
-      await api.admin.removeTeamMember(teamId, userId)
+      await api.admin.removeTeamMember(teamId, member.userId)
       setTeamMembers((prev) => {
-        const updated = (prev.get(teamId) ?? []).filter((m) => m.userId !== userId)
+        const updated = (prev.get(teamId) ?? []).filter((m) => m.userId !== member.userId)
         return new Map(prev).set(teamId, updated)
       })
       setAdminTeams((prev) => prev.map((t) => t.id === teamId ? { ...t, memberCount: t.memberCount - 1 } : t))
+      setRemoveMemberConfirm(null)
     } catch (e: unknown) {
       setRemoveMemberError(e instanceof Error ? e.message : "Failed to remove member")
-      setRemoveMemberErrorTeamId(teamId)
+    } finally {
+      setRemovingMember(false)
     }
   }
 
@@ -162,6 +153,7 @@ export default function AdminTeamsPage() {
               <div key={member.userId}>
                 {j > 0 && <Separator />}
                 <div className="flex items-center gap-3 pl-10 pr-6 py-2.5 group">
+                  <UserAvatar name={member.name} image={member.image} />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm truncate">{member.name}</p>
                     <p className="text-xs text-muted-foreground truncate">{member.email}</p>
@@ -170,7 +162,7 @@ export default function AdminTeamsPage() {
                     <Button
                       size="sm" variant="ghost"
                       className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 shrink-0"
-                      onClick={() => handleAdminRemoveMember(team.id, member.userId)}
+                      onClick={() => { setRemoveMemberError(""); setRemoveMemberConfirm({ teamId: team.id, member }) }}
                       title="Remove member"
                     >
                       ×
@@ -182,41 +174,16 @@ export default function AdminTeamsPage() {
             {!membersLoading && members && members.length === 0 && (
               <p className="text-xs text-muted-foreground pl-10 pr-6 py-2.5">No members.</p>
             )}
-            {removeMemberErrorTeamId === team.id && removeMemberError && (
-              <p className="text-xs text-destructive pl-10 pr-6 py-2">{removeMemberError}</p>
-            )}
             <div className="pl-10 pr-6 py-2 border-t border-border/50 flex items-center justify-between">
               <div className="flex-1">
                 {!team.isPersonal && (
-                  addMemberTeamId === team.id ? (
-                    <form onSubmit={(e) => handleAdminAddMember(e, team.id)} className="flex flex-col gap-2">
-                      <div className="flex gap-2 items-center">
-                        <input
-                          type="email"
-                          placeholder="user@example.com"
-                          value={addMemberEmail}
-                          onChange={(e) => setAddMemberEmail(e.target.value)}
-                          className="h-8 flex-1 rounded-md border border-input bg-background px-3 text-sm"
-                          autoFocus
-                        />
-                        <Button type="submit" size="sm" className="h-8" disabled={!addMemberEmail.trim() || addingMember}>
-                          {addingMember ? "Adding…" : "Add"}
-                        </Button>
-                        <Button type="button" size="sm" variant="ghost" className="h-8" onClick={() => { setAddMemberTeamId(null); setAddMemberEmail(""); setAddMemberError("") }}>
-                          Cancel
-                        </Button>
-                      </div>
-                      {addMemberError && <p className="text-xs text-destructive">{addMemberError}</p>}
-                    </form>
-                  ) : (
-                    <button
-                      type="button"
-                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => { setAddMemberTeamId(team.id); setAddMemberEmail(""); setAddMemberError("") }}
-                    >
-                      + Add member
-                    </button>
-                  )
+                  <button
+                    type="button"
+                    className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    onClick={() => setAddMemberTeamId(team.id)}
+                  >
+                    + Add member
+                  </button>
                 )}
               </div>
               <div className="flex items-center gap-1">
@@ -309,6 +276,36 @@ export default function AdminTeamsPage() {
           </TabsContent>
         </Tabs>
       </div>
+
+      <UserPickerDialog
+        open={addMemberTeamId !== null}
+        onOpenChange={(open) => { if (!open) setAddMemberTeamId(null) }}
+        teamId={addMemberTeamId ?? ""}
+        existingMemberIds={new Set((addMemberTeamId ? (teamMembers.get(addMemberTeamId) ?? []) : []).map((m) => m.userId))}
+        onMemberAdded={() => { if (addMemberTeamId) handleMemberAdded(addMemberTeamId) }}
+      />
+
+      <Dialog open={removeMemberConfirm !== null} onOpenChange={(open) => { if (!open) setRemoveMemberConfirm(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove member</DialogTitle>
+            <DialogDescription>
+              Remove <strong>{removeMemberConfirm?.member.name}</strong> from this team?
+            </DialogDescription>
+          </DialogHeader>
+          {removeMemberError && (
+            <div className="flex items-center gap-2 rounded-md border border-input bg-muted px-3 py-2 mx-6 mb-2">
+              <p className="text-sm text-destructive">{removeMemberError}</p>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveMemberConfirm(null)} disabled={removingMember}>Cancel</Button>
+            <Button variant="destructive" onClick={handleAdminRemoveMember} disabled={removingMember}>
+              {removingMember ? "Removing…" : "Remove"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={renameTeamTarget !== null} onOpenChange={(open) => { if (!open) setRenameTeamTarget(null) }}>
         <DialogContent>

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/members/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/[id]/members/page.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { UserAvatar } from "@/components/ui/user-avatar"
 import { useSession } from "@/lib/auth-client"
 import * as api from "@/lib/api"
 import type { Team, TeamMember } from "@canette/types"
@@ -45,7 +46,7 @@ export default function MembersPage({ params }: { params: Promise<{ id: string }
             <CardDescription>
               {team.isPersonal
                 ? "Your personal team — for your personal projects. You are the only member."
-                : "All members have full access to this team's projects and apps."}
+                : "All members have full access to the team's projects and apps."}
             </CardDescription>
           )}
         </CardHeader>
@@ -66,6 +67,7 @@ export default function MembersPage({ params }: { params: Promise<{ id: string }
                     <div key={member.userId}>
                       {i > 0 && <Separator />}
                       <div className="flex items-center gap-4 px-6 py-3">
+                        <UserAvatar name={member.name} image={member.image} />
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium truncate">{member.name}</p>
                           <p className="text-xs text-muted-foreground truncate">{member.email}</p>

--- a/apps/ui/src/components/ui/user-avatar.tsx
+++ b/apps/ui/src/components/ui/user-avatar.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  name: string
+  image?: string
+}
+
+export function UserAvatar({ name, image }: Props) {
+  return (
+    <div className="size-7 rounded-sm shrink-0 overflow-hidden bg-muted flex items-center justify-center">
+      {image
+        ? <img src={image} alt="" className="size-full object-cover" />
+        : <span className="text-xs font-medium text-muted-foreground leading-none">{name.charAt(0).toUpperCase()}</span>
+      }
+    </div>
+  )
+}

--- a/apps/ui/src/components/user-picker-dialog.tsx
+++ b/apps/ui/src/components/user-picker-dialog.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { UserAvatar } from "@/components/ui/user-avatar"
+import * as api from "@/lib/api"
+import type { User } from "@canette/types"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  teamId: string
+  existingMemberIds: Set<string>
+  onMemberAdded: () => void
+}
+
+export function UserPickerDialog({ open, onOpenChange, teamId, existingMemberIds, onMemberAdded }: Props) {
+  const [users, setUsers] = useState<User[]>([])
+  const [loadingUsers, setLoadingUsers] = useState(false)
+  const [search, setSearch] = useState("")
+  const [addingUserId, setAddingUserId] = useState<string | null>(null)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    if (!open) return
+    setSearch("")
+    setError("")
+    setLoadingUsers(true)
+    api.admin.listUsers()
+      .then(setUsers)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : "Failed to load users"))
+      .finally(() => setLoadingUsers(false))
+  }, [open])
+
+  const filtered = users
+    .filter((u) => !existingMemberIds.has(u.id))
+    .filter((u) => {
+      if (!search.trim()) return true
+      const q = search.toLowerCase()
+      return u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q)
+    })
+  const available = filtered.slice(0, 50)
+  const overflow = filtered.length - available.length
+
+  async function handleAdd(user: User) {
+    setAddingUserId(user.id)
+    setError("")
+    try {
+      await api.admin.addTeamMember(teamId, { userId: user.id })
+      onMemberAdded()
+      onOpenChange(false)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to add member")
+    } finally {
+      setAddingUserId(null)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add member</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 px-6 pb-6">
+          <Input
+            placeholder="Search by name or email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {loadingUsers && (
+            <p className="text-sm text-muted-foreground py-2">Loading…</p>
+          )}
+          {!loadingUsers && available.length === 0 && (
+            <p className="text-sm text-muted-foreground py-2">
+              {search.trim() ? "No users match your search." : "All registered users are already members."}
+            </p>
+          )}
+          {!loadingUsers && available.length > 0 && (
+            <div className="max-h-72 overflow-y-auto -mx-6">
+              {available.map((user, i) => (
+                <div key={user.id}>
+                  {i > 0 && <Separator />}
+                  <div className="flex items-center gap-3 px-6 py-2.5 hover:bg-muted/40">
+                    <UserAvatar name={user.name} image={user.image} />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm truncate">{user.name}</p>
+                      <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 shrink-0"
+                      disabled={addingUserId !== null}
+                      onClick={() => handleAdd(user)}
+                    >
+                      {addingUserId === user.id ? "Adding…" : "Add"}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+              {overflow > 0 && (
+                <p className="text-xs text-muted-foreground px-6 py-2.5 border-t border-border/50">
+                  {overflow} more — type to narrow results
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -33,15 +33,6 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export const teams = {
   list: () => request<Team[]>("/teams"),
   get: (id: string) => request<Team & { members: TeamMember[] }>(`/teams/${id}`),
-  create: (body: { name: string }) =>
-    request<Team>("/teams", { method: "POST", body: JSON.stringify(body) }),
-  rename: (id: string, name: string) =>
-    request<Team>(`/teams/${id}`, { method: "PATCH", body: JSON.stringify({ name }) }),
-  delete: (id: string) => request<void>(`/teams/${id}`, { method: "DELETE" }),
-  addMember: (teamId: string, body: { userId?: string; email?: string }) =>
-    request<void>(`/teams/${teamId}/members`, { method: "POST", body: JSON.stringify(body) }),
-  removeMember: (teamId: string, userId: string) =>
-    request<void>(`/teams/${teamId}/members/${userId}`, { method: "DELETE" }),
   listCredentials: (teamId: string) =>
     request<GitCredential[]>(`/teams/${teamId}/credentials`),
   createCredential: (teamId: string, body: { name: string; provider: GitProvider; type: GitCredentialType; value?: string; sshKnownHosts?: string }) =>
@@ -162,6 +153,15 @@ export const admin = {
     request<void>(`/admin/users/${id}`, { method: "DELETE", body: JSON.stringify({ force }) }),
   getOverview: () => request<AdminProjectOverview[]>("/admin/overview"),
   getTeams: () => request<AdminTeamOverview[]>("/admin/teams"),
+  createTeam: (body: { name: string }) =>
+    request<Team>("/admin/teams", { method: "POST", body: JSON.stringify(body) }),
+  renameTeam: (id: string, name: string) =>
+    request<Team>(`/admin/teams/${id}`, { method: "PATCH", body: JSON.stringify({ name }) }),
+  deleteTeam: (id: string) => request<void>(`/admin/teams/${id}`, { method: "DELETE" }),
+  addTeamMember: (teamId: string, body: { userId?: string; email?: string }) =>
+    request<void>(`/admin/teams/${teamId}/members`, { method: "POST", body: JSON.stringify(body) }),
+  removeTeamMember: (teamId: string, userId: string) =>
+    request<void>(`/admin/teams/${teamId}/members/${userId}`, { method: "DELETE" }),
   sync: () => request<SyncResult>("/admin/sync", { method: "POST" }),
   resetStuck: () => request<SyncResult>("/admin/reset-stuck", { method: "POST" }),
   getScanPolicy: () => request<ScanPolicy>("/admin/settings/security"),


### PR DESCRIPTION
## Summary

- All admin-only team mutations (create, rename, delete, add/remove members) moved from the teams router to the dedicated `/api/v1/admin/teams` router, where `requireAdmin` is enforced globally rather than per-route
- Admins can now rename personal teams (previously blocked with 403)
- Removing a team owner auto-reassigns `owner_id` to the longest-standing remaining member instead of returning 409; removing the last member still blocks with a clear error
- Replaces the email text input for adding members with a user picker dialog — lists all registered users not already in the team, with client-side search by name or email, capped at 50 results with an overflow hint (closes #33)
- Extracts a shared `UserAvatar` component (28px square, initial fallback) used across the picker, admin member list, and dashboard members page
- Member removal now requires confirmation via a dialog rather than firing immediately

## Test plan

- [ ] Rename a personal team from Admin → Teams → Personal tab
- [ ] Add a member via the picker dialog — confirm search filters by name and email, existing members are excluded
- [ ] Add a member when >50 are available — confirm overflow hint appears
- [ ] Remove a team member — confirm confirmation dialog appears, error message shows on failure (e.g. last member)
- [ ] Remove the team owner — confirm ownership transfers to the next-oldest member
- [ ] Verify avatars appear in the picker, admin member list, and dashboard members page

🤖 Generated with [Claude Code](https://claude.com/claude-code)