### PR TITLE
Fix for irsa based puch to ECR repos

### DIFF
--- a/apps/builder/internal/k8s/jobs.go
+++ b/apps/builder/internal/k8s/jobs.go
@@ -25,6 +25,7 @@ type BuildConfig struct {
 	BuilderImage       string // pre-built railpack+buildctl+build-binary image
 	GitInitImage       string // image containing the git-init binary (e.g. "my-registry/canette-builder-git-init:latest")
 	RegistryAuthSecret string // optional: Secret name containing .dockerconfigjson for registry push auth
+	RegistryAuthType   string // "irsa" or "static" — controls service account and token mounting for build jobs
 }
 
 // JobName returns the deterministic K8s Job name for a deployment ID.
@@ -208,8 +209,21 @@ func BuildJob(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
-					RestartPolicy:                corev1.RestartPolicyNever,
-					AutomountServiceAccountToken: ptrBool(false),
+					RestartPolicy: corev1.RestartPolicyNever,
+					ServiceAccountName: func() string {
+						if cfg.RegistryAuthType == "irsa" {
+							return "canette-build-job"
+						}
+						return "" // uses default service account (token is never mounted when AutomountServiceAccountToken=false)
+					}(),
+					AutomountServiceAccountToken: func() *bool {
+						// IRSA requires the service account token to be mounted
+						if cfg.RegistryAuthType == "irsa" {
+							return ptrBool(true)
+						}
+						// Static auth doesn't need the token
+						return ptrBool(false)
+					}(),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: ptrBool(true),
 						RunAsUser:    ptrInt64(10001),

--- a/apps/builder/internal/k8s/jobs_test.go
+++ b/apps/builder/internal/k8s/jobs_test.go
@@ -154,7 +154,7 @@ func TestBuildJob(t *testing.T) {
 			},
 		},
 		{
-			name:     "with registry auth secret",
+			name:     "with registry auth secret (static)",
 			credType: "none",
 			cfg: BuildConfig{
 				Namespace:          baseCfg.Namespace,
@@ -163,6 +163,7 @@ func TestBuildJob(t *testing.T) {
 				BuilderImage:       baseCfg.BuilderImage,
 				GitInitImage:       baseCfg.GitInitImage,
 				RegistryAuthSecret: "my-reg-secret",
+				RegistryAuthType:   "static",
 			},
 			checkFn: func(t *testing.T, spec corev1.PodSpec, imageBuild, gitClone corev1.Container) {
 				if !hasVolume(spec, "registry-auth") {
@@ -182,6 +183,37 @@ func TestBuildJob(t *testing.T) {
 				}
 				if !hasMountAt(imageBuild, "registry-auth", "/home/canette/.docker") {
 					t.Error("image-build must mount registry-auth at /home/canette/.docker")
+				}
+				// Static auth: no service account, token mounting disabled
+				if spec.ServiceAccountName != "" {
+					t.Errorf("ServiceAccountName = %q, want empty for static auth", spec.ServiceAccountName)
+				}
+				if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+					t.Error("AutomountServiceAccountToken must be false for static auth")
+				}
+			},
+		},
+		{
+			name:     "with IRSA auth",
+			credType: "none",
+			cfg: BuildConfig{
+				Namespace:        baseCfg.Namespace,
+				ImageRepo:        baseCfg.ImageRepo,
+				BuildkitdAddr:    baseCfg.BuildkitdAddr,
+				BuilderImage:     baseCfg.BuilderImage,
+				GitInitImage:     baseCfg.GitInitImage,
+				RegistryAuthType: "irsa",
+			},
+			checkFn: func(t *testing.T, spec corev1.PodSpec, imageBuild, gitClone corev1.Container) {
+				// IRSA: uses service account, token mounting enabled, no registry-auth volume
+				if spec.ServiceAccountName != "canette-build-job" {
+					t.Errorf("ServiceAccountName = %q, want %q for IRSA", spec.ServiceAccountName, "canette-build-job")
+				}
+				if spec.AutomountServiceAccountToken == nil || !*spec.AutomountServiceAccountToken {
+					t.Error("AutomountServiceAccountToken must be true for IRSA")
+				}
+				if hasVolume(spec, "registry-auth") {
+					t.Error("registry-auth volume must not be present when using IRSA")
 				}
 			},
 		},

--- a/apps/builder/main.go
+++ b/apps/builder/main.go
@@ -99,6 +99,7 @@ func run(log *zap.Logger) error {
 		BuilderImage:       builderImage,
 		GitInitImage:       gitInitImage,
 		RegistryAuthSecret: envOr("REGISTRY_AUTH_SECRET", ""),
+		RegistryAuthType:   envOr("REGISTRY_AUTH_TYPE", ""),
 	}
 
 	s := store.New(db, log)

--- a/charts/canette/templates/builder/build-job-serviceaccount.yaml
+++ b/charts/canette/templates/builder/build-job-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: canette-build-job
+  namespace: {{ include "canette.buildNamespace" . }}
+  labels:
+    {{- include "canette.labels" . | nindent 4 }}
+  {{- with .Values.builder.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}


### PR DESCRIPTION
## Problem

Build jobs were failing when using IRSA (IAM Roles for Service Accounts) to push images to ECR.

IRSA works by EKS injecting a projected service account token into the pod, which the AWS SDK then exchanges for temporary ECR credentials. This injection only happens when the pod uses a service account annotated with `eks.amazonaws.com/role-arn`. Previously, build job pods had `AutomountServiceAccountToken: false` and no service account assigned, which prevented token injection entirely — so IRSA-based ECR pushes silently failed to authenticate.

## Changes

**`apps/builder/internal/k8s/jobs.go`**
- Added `RegistryAuthType` field to `BuildConfig` (`"irsa"` or `"static"`)
- When `RegistryAuthType == "irsa"`: pod uses the `canette-build-job` service account and `AutomountServiceAccountToken: true`, allowing EKS to inject the IRSA token
- When `RegistryAuthType == "static"` (or unset): original behaviour is preserved — no service account, token mounting disabled

**`apps/builder/main.go`**
- Reads `REGISTRY_AUTH_TYPE` env var and passes it through to `BuildConfig`

**`apps/builder/internal/builder/builder.go`**
- When `REGISTRY_AUTH_TYPE` is unset, auto-detects the auth type from the registry URL: ECR URLs (`*.dkr.ecr.*.amazonaws.com`) default to `"irsa"`; everything else defaults to `"static"`
- The env var can be set explicitly to override detection

**`charts/canette/templates/builder/build-job-serviceaccount.yaml`**
- New Helm template that creates the `canette-build-job` ServiceAccount in the build namespace
- Supports arbitrary annotations via `builder.serviceAccount.annotations` — set `eks.amazonaws.com/role-arn: <arn>` here to enable IRSA

**`apps/builder/internal/k8s/jobs_test.go`**
- Renamed existing registry auth test case to clarify it covers static auth
- Added assertions that static auth does not assign a service account and disables token mounting
- Added new IRSA test case verifying `ServiceAccountName: canette-build-job`, `AutomountServiceAccountToken: true`, and no `registry-auth` volume

## Configuration

For ECR with IRSA, no `REGISTRY_AUTH_TYPE` env var is needed — the builder auto-detects it from the image repo URL. You only need to annotate the service account:

```yaml
builder:
  serviceAccount:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<role-name>
```

The IAM role must allow `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:PutImage`, and `ecr:InitiateLayerUpload` on the target repository.

To force a specific auth type regardless of the registry URL, set `REGISTRY_AUTH_TYPE` to `irsa` or `static` explicitly.