### PR TITLE
fix(builder): correct IRSA auth type propagation + add flow tests

### DIFF
--- a/apps/builder/internal/builder/build_flow_test.go
+++ b/apps/builder/internal/builder/build_flow_test.go
@@ -1,0 +1,201 @@
+package builder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	k8sjobs "canette.dev/builder/internal/k8s"
+	"canette.dev/builder/internal/scanner"
+	"canette.dev/builder/internal/store"
+)
+
+// fakeStore satisfies Storer for tests. ClaimPending returns a fixed set of
+// deployments on the first call and nothing thereafter.
+type fakeStore struct {
+	deployments []store.PendingDeployment
+	called      bool
+
+	appendedLogs []string
+	markedFailed []string
+	markedDeploy []string
+}
+
+func (f *fakeStore) ClaimPending(_ context.Context, _ int) ([]store.PendingDeployment, error) {
+	if f.called {
+		return nil, nil
+	}
+	f.called = true
+	return f.deployments, nil
+}
+func (f *fakeStore) AppendLog(_ context.Context, _ string, _ string, line string) error {
+	f.appendedLogs = append(f.appendedLogs, line)
+	return nil
+}
+func (f *fakeStore) MarkFailed(_ context.Context, id, _ string) error {
+	f.markedFailed = append(f.markedFailed, id)
+	return nil
+}
+func (f *fakeStore) GetGitCredential(_ context.Context, _ string) (*store.GitCredential, error) {
+	return nil, nil
+}
+func (f *fakeStore) SetDeploymentCanetteConfig(_ context.Context, _, _ string) error { return nil }
+func (f *fakeStore) UpdateCommitSha(_ context.Context, _, _ string) error             { return nil }
+func (f *fakeStore) MarkScanning(_ context.Context, _, _ string) error                { return nil }
+func (f *fakeStore) SetScanResults(_ context.Context, _, _, _, _ string) error        { return nil }
+func (f *fakeStore) MarkDeploying(_ context.Context, id, _ string) error {
+	f.markedDeploy = append(f.markedDeploy, id)
+	return nil
+}
+
+func hasVolume(spec corev1.PodSpec, name string) bool {
+	for _, v := range spec.Volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// genericRepo is a plain registry URL — DetectProvider returns "generic" so
+// no AWS calls are made during tests.
+const genericRepo = "registry.example.com/canette/"
+
+// pendingDep returns a minimal PendingDeployment with no git credentials.
+func pendingDep(id string) store.PendingDeployment {
+	return store.PendingDeployment{
+		ID:          id,
+		CommitSha:   "abc1234",
+		AppID:       "app-1",
+		AppSlug:     "myapp",
+		ProjectSlug: "myproject",
+		SourceType:  "git",
+		GitURL:      "https://github.com/example/repo.git",
+		GitBranch:   "main",
+	}
+}
+
+// runBuildOnce triggers one processPending cycle on the builder and returns
+// after all goroutines spawned by that cycle complete.
+func runBuildOnce(t *testing.T, b *Builder) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.processPending(ctx); err != nil {
+		t.Fatalf("processPending: %v", err)
+	}
+}
+
+func newBuildFlowBuilder(t *testing.T, fs *fakeStore, k8s *fake.Clientset, authType string) *Builder {
+	t.Helper()
+	return New(
+		fs,
+		k8s,
+		k8sjobs.BuildConfig{
+			Namespace:        "canette-system",
+			ImageRepo:        genericRepo,
+			BuildkitdAddr:    "tcp://buildkitd:1234",
+			BuilderImage:     "registry.example.com/canette-builder:latest",
+			GitInitImage:     "registry.example.com/canette-git-init:latest",
+			RegistryAuthType: authType,
+		},
+		nil,            // cryptoKey — not needed (no git credentials in these tests)
+		zap.NewNop(),
+		time.Second,
+		1,
+		scanner.Config{}, // NoneProvider
+	)
+}
+
+// jobFromFake retrieves the single Job the builder created in the fake client.
+func jobFromFake(t *testing.T, k8s *fake.Clientset) corev1.PodSpec {
+	t.Helper()
+	jobs, err := k8s.BatchV1().Jobs("canette-system").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) == 0 {
+		t.Fatal("no Job was created in the fake k8s client")
+	}
+	return jobs.Items[0].Spec.Template.Spec
+}
+
+func TestBuildFlow_StaticAuth_NoServiceAccount(t *testing.T) {
+	dep := pendingDep("d59d1c36-0000-0000-0000-000000000001")
+	fs := &fakeStore{deployments: []store.PendingDeployment{dep}}
+	k8s := fake.NewSimpleClientset()
+
+	b := newBuildFlowBuilder(t, fs, k8s, "static")
+	runBuildOnce(t, b)
+
+	spec := jobFromFake(t, k8s)
+
+	if spec.ServiceAccountName != "" {
+		t.Errorf("ServiceAccountName = %q, want empty for static auth", spec.ServiceAccountName)
+	}
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		t.Error("AutomountServiceAccountToken must be false for static auth")
+	}
+}
+
+func TestBuildFlow_IRSAAuth_UsesServiceAccount(t *testing.T) {
+	dep := pendingDep("d59d1c36-0000-0000-0000-000000000002")
+	fs := &fakeStore{deployments: []store.PendingDeployment{dep}}
+	k8s := fake.NewSimpleClientset()
+
+	b := newBuildFlowBuilder(t, fs, k8s, "irsa")
+	runBuildOnce(t, b)
+
+	spec := jobFromFake(t, k8s)
+
+	const wantSA = "canette-build-job"
+	if spec.ServiceAccountName != wantSA {
+		t.Errorf("ServiceAccountName = %q, want %q for IRSA", spec.ServiceAccountName, wantSA)
+	}
+	if spec.AutomountServiceAccountToken == nil || !*spec.AutomountServiceAccountToken {
+		t.Error("AutomountServiceAccountToken must be true for IRSA")
+	}
+	if hasVolume(spec, "registry-auth") {
+		t.Error("registry-auth volume must not be present when using IRSA")
+	}
+}
+
+func TestBuildFlow_ECRRepo_AutoDetectsIRSA(t *testing.T) {
+	dep := pendingDep("d59d1c36-0000-0000-0000-000000000003")
+	dep.ProjectSlug = "myproject"
+	dep.AppSlug = "myapp"
+	fs := &fakeStore{deployments: []store.PendingDeployment{dep}}
+	k8s := fake.NewSimpleClientset()
+
+	// RegistryAuthType is empty — should auto-detect "irsa" from ECR URL.
+	b := New(
+		fs,
+		k8s,
+		k8sjobs.BuildConfig{
+			Namespace:     "canette-system",
+			ImageRepo:     "123456789012.dkr.ecr.us-east-1.amazonaws.com/canette/",
+			BuildkitdAddr: "tcp://buildkitd:1234",
+			BuilderImage:  "registry.example.com/canette-builder:latest",
+			GitInitImage:  "registry.example.com/canette-git-init:latest",
+			// RegistryAuthType intentionally omitted
+		},
+		nil,
+		zap.NewNop(),
+		time.Second,
+		1,
+		scanner.Config{},
+	)
+
+	// Resolved auth type must be "irsa" before any build happens.
+	if b.cfg.RegistryAuthType != "irsa" {
+		t.Fatalf("auto-detected RegistryAuthType = %q, want %q", b.cfg.RegistryAuthType, "irsa")
+	}
+	if b.registryConfig.AuthType != "irsa" {
+		t.Fatalf("registryConfig.AuthType = %q, want %q", b.registryConfig.AuthType, "irsa")
+	}
+}

--- a/apps/builder/internal/builder/builder.go
+++ b/apps/builder/internal/builder/builder.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -34,8 +33,21 @@ func base64Decode(s string) ([]byte, error) {
 }
 
 // Builder polls the database for pending deployments and runs them as K8s Jobs.
+// Storer is the subset of store.Store methods used by the builder.
+type Storer interface {
+	ClaimPending(ctx context.Context, limit int) ([]store.PendingDeployment, error)
+	AppendLog(ctx context.Context, deploymentID, stream, line string) error
+	MarkFailed(ctx context.Context, deploymentID, errMsg string) error
+	GetGitCredential(ctx context.Context, id string) (*store.GitCredential, error)
+	SetDeploymentCanetteConfig(ctx context.Context, deploymentID, yamlContent string) error
+	UpdateCommitSha(ctx context.Context, deploymentID, sha string) error
+	MarkScanning(ctx context.Context, deploymentID, scanJobName string) error
+	SetScanResults(ctx context.Context, deploymentID, scanStatus, scanSummary, sbom string) error
+	MarkDeploying(ctx context.Context, deploymentID, imageDigest string) error
+}
+
 type Builder struct {
-	store          *store.Store
+	store          Storer
 	k8s            kubernetes.Interface
 	cfg            k8sjobs.BuildConfig
 	cryptoKey      []byte
@@ -49,7 +61,7 @@ type Builder struct {
 
 // New creates a Builder.
 func New(
-	s *store.Store,
+	s Storer,
 	k kubernetes.Interface,
 	cfg k8sjobs.BuildConfig,
 	cryptoKey []byte,
@@ -58,14 +70,12 @@ func New(
 	maxConcurrent int,
 	scanCfg scanner.Config,
 ) *Builder {
-	// Read registry auth type from env, defaulting based on detected provider
-	registryAuthType := os.Getenv("REGISTRY_AUTH_TYPE")
-	if registryAuthType == "" {
-		provider := registry.DetectProvider(cfg.ImageRepo)
-		if provider == "ecr" {
-			registryAuthType = "irsa"
+	// Resolve registry auth type: explicit env var wins, otherwise detect from image repo URL.
+	if cfg.RegistryAuthType == "" {
+		if registry.DetectProvider(cfg.ImageRepo) == "ecr" {
+			cfg.RegistryAuthType = "irsa"
 		} else {
-			registryAuthType = "static"
+			cfg.RegistryAuthType = "static"
 		}
 	}
 
@@ -87,7 +97,7 @@ func New(
 		maxConcurrent: maxConcurrent,
 		registryConfig: registry.Config{
 			ImageRepo: cfg.ImageRepo,
-			AuthType:  registryAuthType,
+			AuthType:  cfg.RegistryAuthType,
 		},
 		scanProvider:  scanProvider,
 		scanProviderName: providerName,

--- a/apps/builder/internal/builder/builder_test.go
+++ b/apps/builder/internal/builder/builder_test.go
@@ -1,0 +1,81 @@
+package builder
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	k8sjobs "canette.dev/builder/internal/k8s"
+	"canette.dev/builder/internal/scanner"
+)
+
+func newTestBuilder(imageRepo, registryAuthType string) *Builder {
+	return New(
+		nil, // store — not used during construction
+		nil, // k8s   — not used during construction
+		k8sjobs.BuildConfig{
+			ImageRepo:        imageRepo,
+			RegistryAuthType: registryAuthType,
+		},
+		nil,                    // cryptoKey
+		zap.NewNop(),
+		time.Second,
+		1,
+		scanner.Config{},       // empty → NoneProvider
+	)
+}
+
+func TestRegistryAuthTypeResolution(t *testing.T) {
+	ecrRepo    := "123456789012.dkr.ecr.us-east-1.amazonaws.com/canette/"
+	genericRepo := "registry.example.com/canette/"
+
+	tests := []struct {
+		name             string
+		imageRepo        string
+		registryAuthType string // empty = auto-detect
+		wantAuthType     string
+	}{
+		{
+			name:         "ECR URL auto-detects irsa",
+			imageRepo:    ecrRepo,
+			wantAuthType: "irsa",
+		},
+		{
+			name:         "non-ECR URL auto-detects static",
+			imageRepo:    genericRepo,
+			wantAuthType: "static",
+		},
+		{
+			name:             "explicit irsa overrides ECR auto-detect",
+			imageRepo:        ecrRepo,
+			registryAuthType: "irsa",
+			wantAuthType:     "irsa",
+		},
+		{
+			name:             "explicit static overrides ECR auto-detect",
+			imageRepo:        ecrRepo,
+			registryAuthType: "static",
+			wantAuthType:     "static",
+		},
+		{
+			name:             "explicit irsa overrides non-ECR auto-detect",
+			imageRepo:        genericRepo,
+			registryAuthType: "irsa",
+			wantAuthType:     "irsa",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBuilder(tc.imageRepo, tc.registryAuthType)
+
+			if got := b.cfg.RegistryAuthType; got != tc.wantAuthType {
+				t.Errorf("cfg.RegistryAuthType = %q, want %q", got, tc.wantAuthType)
+			}
+			if got := b.registryConfig.AuthType; got != tc.wantAuthType {
+				t.Errorf("registryConfig.AuthType = %q, want %q", got, tc.wantAuthType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`New()` in the builder resolved the `RegistryAuthType` (auto-detecting `irsa` for ECR URLs, `static` otherwise) but stored the result only in a local variable. `b.cfg.RegistryAuthType` and `b.registryConfig.AuthType` were left as the raw value from the env var — empty when `REGISTRY_AUTH_TYPE` is unset. Every build job was therefore created with an empty auth type, meaning no service account was set and IRSA pushes to ECR silently failed to authenticate.

## Changes

**`builder.go` — bug fix**
- Mutate `cfg.RegistryAuthType` in place (before storing `cfg` on the struct) so both `b.cfg` (used to construct the K8s Job) and `b.registryConfig` (used by the ECR provider) see the resolved value.
- Remove the now-unused `os` import.

**`builder.go` — Storer interface**
- Extract a `Storer` interface covering the 9 `*store.Store` methods the builder calls.
- Change the `store` field and `New()` parameter from `*store.Store` to `Storer`.
- `*store.Store` satisfies the interface implicitly — no production wiring changes.

**`builder_test.go` — auth type unit tests**
- 5 cases covering ECR URL auto-detect → `irsa`, non-ECR auto-detect → `static`, and explicit overrides in both directions.
- Asserts both `b.cfg.RegistryAuthType` and `b.registryConfig.AuthType` so a regression like the original bug would be caught.

**`build_flow_test.go` — end-to-end flow tests**
- `fakeStore` implements `Storer` and returns a fixed `PendingDeployment` on first call.
- Uses `client-go/kubernetes/fake` as the K8s client.
- Uses a non-ECR image repo so the generic registry provider is used (no AWS calls).
- Calls `processPending()` directly and inspects the `Job` that lands in the fake client:
  - `StaticAuth_NoServiceAccount`: no SA, `AutomountServiceAccountToken=false`
  - `IRSAAuth_UsesServiceAccount`: SA=`canette-build-job`, `AutomountServiceAccountToken=true`, no `registry-auth` volume
  - `ECRRepo_AutoDetectsIRSA`: asserts resolved config fields without triggering a build (ECR provider requires AWS)

## Test plan

- [ ] `go test ./internal/builder/... ./internal/k8s/...` passes locally
- [ ] All CI checks pass (linting + full test suite via pre-push hook)