### PR TITLE
fix(registry): strip path prefix from auths key in docker config JSON

### DIFF
--- a/apps/builder/internal/registry/registry.go
+++ b/apps/builder/internal/registry/registry.go
@@ -55,8 +55,10 @@ func NewProvider(cfg Config) (Provider, error) {
 	}
 }
 
-// BuildDockerConfigJSON creates a Docker config.json for BuildKit
-func BuildDockerConfigJSON(registryURL string, auth *AuthConfig) (string, error) {
+// BuildDockerConfigJSON creates a Docker config.json for BuildKit.
+// imageRepo may include a path prefix (e.g. "host.example.com/org/"); only
+// the hostname is used as the auths key so Docker and buildctl can match it.
+func BuildDockerConfigJSON(imageRepo string, auth *AuthConfig) (string, error) {
 	if auth == nil {
 		// IRSA: return empty config, credentials come from environment
 		return "{}", nil
@@ -64,7 +66,7 @@ func BuildDockerConfigJSON(registryURL string, auth *AuthConfig) (string, error)
 
 	config := DockerConfigJSON{
 		Auths: map[string]AuthConfig{
-			registryURL: *auth,
+			ExtractRegistryURL(imageRepo): *auth,
 		},
 	}
 

--- a/apps/builder/internal/registry/registry_test.go
+++ b/apps/builder/internal/registry/registry_test.go
@@ -1,0 +1,65 @@
+package registry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildDockerConfigJSON_HostnameOnly(t *testing.T) {
+	// IMAGE_REPO includes a path prefix after the hostname, e.g.
+	// "123456789012.dkr.ecr.us-east-1.amazonaws.com/canette/"
+	// The auths key in config.json must be the bare hostname — Docker and
+	// buildctl match credentials by registry host, not by image path.
+	tests := []struct {
+		name      string
+		imageRepo string
+		wantHost  string
+	}{
+		{
+			name:      "ECR with path prefix",
+			imageRepo: "123456789012.dkr.ecr.us-east-1.amazonaws.com/canette/",
+			wantHost:  "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+		},
+		{
+			name:      "ECR without path prefix",
+			imageRepo: "123456789012.dkr.ecr.us-east-1.amazonaws.com/",
+			wantHost:  "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+		},
+		{
+			name:      "generic registry with path",
+			imageRepo: "registry.example.com/myorg/",
+			wantHost:  "registry.example.com",
+		},
+	}
+
+	auth := &AuthConfig{Username: "AWS", Password: "token"}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := BuildDockerConfigJSON(tc.imageRepo, auth)
+			if err != nil {
+				t.Fatalf("BuildDockerConfigJSON error: %v", err)
+			}
+
+			var cfg DockerConfigJSON
+			if err := json.Unmarshal([]byte(out), &cfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			if _, ok := cfg.Auths[tc.wantHost]; !ok {
+				keys := make([]string, 0, len(cfg.Auths))
+				for k := range cfg.Auths {
+					keys = append(keys, k)
+				}
+				t.Errorf("auths key = %v, want %q (must be hostname only, no path)", keys, tc.wantHost)
+			}
+
+			for k := range cfg.Auths {
+				if strings.Contains(k, "/") {
+					t.Errorf("auths key %q contains a path — must be hostname only", k)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`BuildDockerConfigJSON` was keying the `auths` map with the full `IMAGE_REPO` value, which includes the repository path prefix:

```json
{
  "auths": {
    "123456789012.dkr.ecr.us-east-1.amazonaws.com/canette/": { ... }
  }
}
```

Docker and buildctl match credentials by **hostname only**. With a path in the key, no credential match is found and the push fails with 401.

## Fix

Pass `imageRepo` through the existing `ExtractRegistryURL()` helper before using it as the `auths` key:

```json
{
  "auths": {
    "123456789012.dkr.ecr.us-east-1.amazonaws.com": { ... }
  }
}
```

## Test

Added `registry_test.go` with `TestBuildDockerConfigJSON_HostnameOnly` covering three cases — ECR with path prefix, ECR without path prefix, and a generic registry with an org path. All three failed before the fix and pass after.

## Test plan

- [ ] `go test ./internal/registry/...` passes
- [ ] All CI checks pass
- [ ] ECR push succeeds end-to-end with IRSA