### PR TITLE
docs(aws): fix two incorrect IAM actions in ECR policy

### DIFF
--- a/apps/docs/content/docs/self-hosting/aws.mdx
+++ b/apps/docs/content/docs/self-hosting/aws.mdx
@@ -111,6 +111,7 @@ Attach this permissions policy to the role:
       "Effect": "Allow",
       "Action": [
         "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
         "ecr:PutImage",
         "ecr:InitiateLayerUpload",
         "ecr:UploadLayerPart",
@@ -122,7 +123,7 @@ Attach this permissions policy to the role:
       "Sid": "ECRScanning",
       "Effect": "Allow",
       "Action": [
-        "ecr:InitiateImageScan",
+        "ecr:StartImageScan",
         "ecr:DescribeImageScanFindings"
       ],
       "Resource": "arn:aws:ecr:REGION:ACCOUNT_ID:repository/canette/*"


### PR DESCRIPTION
## Summary

- Add missing `ecr:BatchGetImage` to the ECRPush statement — required for image push to succeed
- Fix `ecr:InitiateImageScan` → `ecr:StartImageScan` in the ECRScanning statement — the former is not a valid ECR API action

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)