### PR TITLE
feat: template wizard for multi-app creation from canette-template.yaml

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,11 +19,13 @@
     "better-auth": "^1.6.6",
     "hono": "4.12.18",
     "jose": "^6.2.3",
+    "js-yaml": "^4.1.1",
     "kysely": "^0.28.16",
     "pg": "^8.13.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/js-yaml": "^4.0.9",
     "@types/pg": "^8.11.0",
     "bun-types": "^1.3.13",
     "eslint": "^10.2.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import { usersRouter } from "./routes/users"
 import { githubAppRouter } from "./routes/github-app"
 import { wellKnownRouter, oauthRouter } from "./routes/oauth"
 import { mcpRouter } from "./routes/mcp"
+import { templatesRouter } from "./routes/templates"
 
 export function createApp() {
     const app = new Hono()
@@ -70,6 +71,7 @@ export function createApp() {
     api.route("/admin", adminRouter)
     api.route("/users", usersRouter)
     api.route("/github-app", githubAppRouter)
+    api.route("/", templatesRouter)
 
     // OAuth 2.1 AS and MCP (unauthenticated at router level — bearer auth applied in mcpRouter)
     app.route("/.well-known", wellKnownRouter)

--- a/apps/api/src/routes/templates.ts
+++ b/apps/api/src/routes/templates.ts
@@ -8,12 +8,12 @@ export const templatesRouter = new Hono<AppEnv>()
 
 templatesRouter.use("*", requireAuth)
 
-// Parse a canette-template.yaml from inline YAML or a URL.
+// Parse a canette-template.yaml from inline YAML.
 // POST /api/v1/templates/parse
 templatesRouter.post("/templates/parse", async (c) => {
-  const body = await c.req.json<{ yaml?: string; url?: string }>()
+  const body = await c.req.json<{ yaml?: string }>()
   try {
-    const template = await parseTemplate(body)
+    const template = await parseTemplate({ yaml: body.yaml ?? "" })
     return c.json(template)
   } catch (e) {
     if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)

--- a/apps/api/src/routes/templates.ts
+++ b/apps/api/src/routes/templates.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono"
+import { requireAuth } from "../middleware/require-auth"
+import { parseTemplate } from "../services/templates"
+import { ServiceError } from "../services/errors"
+import type { AppEnv } from "../types"
+
+export const templatesRouter = new Hono<AppEnv>()
+
+templatesRouter.use("*", requireAuth)
+
+// Parse a canette-template.yaml from inline YAML or a URL.
+// POST /api/v1/templates/parse
+templatesRouter.post("/templates/parse", async (c) => {
+  const body = await c.req.json<{ yaml?: string; url?: string }>()
+  try {
+    const template = await parseTemplate(body)
+    return c.json(template)
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
+})

--- a/apps/api/src/services/templates.ts
+++ b/apps/api/src/services/templates.ts
@@ -4,9 +4,6 @@ import type { AppTemplate, AppSourceType, TemplateApp } from "@canette/types"
 
 const MAX_TEMPLATE_SIZE = 50 * 1024
 
-// RFC-1918 + loopback
-const PRIVATE_HOST_RE = /^(localhost|127\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)/
-
 // Fields consumed directly into the App row or as separate API calls.
 // Everything else is serialised back to YAML and stored as canetteConfig.
 const APP_ROW_FIELDS = new Set([
@@ -14,44 +11,6 @@ const APP_ROW_FIELDS = new Set([
   "git_credential_id", "app_path", "image_url", "image_tag",
   "port", "env", "secrets",
 ])
-
-function assertPrivateHost(hostname: string) {
-  if (PRIVATE_HOST_RE.test(hostname)) {
-    throw new ServiceError("URL points to a private or loopback address", "FORBIDDEN_URL", 400)
-  }
-}
-
-async function fetchTemplateYaml(url: string): Promise<string> {
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    throw new ServiceError("Invalid URL", "INVALID_URL", 400)
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new ServiceError("Only http and https URLs are allowed", "INVALID_URL", 400)
-  }
-  assertPrivateHost(parsed.hostname)
-
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 5000)
-  try {
-    const res = await fetch(url, { signal: controller.signal })
-    if (!res.ok) {
-      throw new ServiceError(`Failed to fetch template: HTTP ${res.status}`, "FETCH_ERROR", 400)
-    }
-    const text = await res.text()
-    if (text.length > MAX_TEMPLATE_SIZE) {
-      throw new ServiceError("Template file exceeds the 50 KB limit", "TOO_LARGE", 400)
-    }
-    return text
-  } catch (e) {
-    if (e instanceof ServiceError) throw e
-    throw new ServiceError("Failed to fetch template URL", "FETCH_ERROR", 400)
-  } finally {
-    clearTimeout(timeout)
-  }
-}
 
 function parseTemplateApp(raw: Record<string, unknown>, index: number): TemplateApp {
   const name = raw.name
@@ -126,19 +85,11 @@ function parseTemplateApp(raw: Record<string, unknown>, index: number): Template
   }
 }
 
-export async function parseTemplate(input: { yaml?: string; url?: string }): Promise<AppTemplate> {
-  let yamlContent: string
-
-  if (input.url) {
-    yamlContent = await fetchTemplateYaml(input.url)
-  } else if (input.yaml) {
-    if (input.yaml.length > MAX_TEMPLATE_SIZE) {
-      throw new ServiceError("Template exceeds the 50 KB limit", "TOO_LARGE", 400)
-    }
-    yamlContent = input.yaml
-  } else {
-    throw new ServiceError("Either 'yaml' or 'url' is required", "MISSING_INPUT", 400)
+export async function parseTemplate(input: { yaml: string }): Promise<AppTemplate> {
+  if (input.yaml.length > MAX_TEMPLATE_SIZE) {
+    throw new ServiceError("Template exceeds the 50 KB limit", "TOO_LARGE", 400)
   }
+  const yamlContent = input.yaml
 
   let doc: unknown
   try {

--- a/apps/api/src/services/templates.ts
+++ b/apps/api/src/services/templates.ts
@@ -1,0 +1,184 @@
+import jsyaml from "js-yaml"
+import { ServiceError } from "./errors"
+import type { AppTemplate, AppSourceType, TemplateApp } from "@canette/types"
+
+const MAX_TEMPLATE_SIZE = 50 * 1024
+
+// RFC-1918 + loopback
+const PRIVATE_HOST_RE = /^(localhost|127\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)/
+
+// Fields consumed directly into the App row or as separate API calls.
+// Everything else is serialised back to YAML and stored as canetteConfig.
+const APP_ROW_FIELDS = new Set([
+  "name", "slug", "source_type", "git_url", "git_branch",
+  "git_credential_id", "app_path", "image_url", "image_tag",
+  "port", "env", "secrets",
+])
+
+function assertPrivateHost(hostname: string) {
+  if (PRIVATE_HOST_RE.test(hostname)) {
+    throw new ServiceError("URL points to a private or loopback address", "FORBIDDEN_URL", 400)
+  }
+}
+
+async function fetchTemplateYaml(url: string): Promise<string> {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new ServiceError("Invalid URL", "INVALID_URL", 400)
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ServiceError("Only http and https URLs are allowed", "INVALID_URL", 400)
+  }
+  assertPrivateHost(parsed.hostname)
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) {
+      throw new ServiceError(`Failed to fetch template: HTTP ${res.status}`, "FETCH_ERROR", 400)
+    }
+    const text = await res.text()
+    if (text.length > MAX_TEMPLATE_SIZE) {
+      throw new ServiceError("Template file exceeds the 50 KB limit", "TOO_LARGE", 400)
+    }
+    return text
+  } catch (e) {
+    if (e instanceof ServiceError) throw e
+    throw new ServiceError("Failed to fetch template URL", "FETCH_ERROR", 400)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function parseTemplateApp(raw: Record<string, unknown>, index: number): TemplateApp {
+  const name = raw.name
+  const slug = raw.slug
+
+  if (typeof name !== "string" || !name.trim()) {
+    throw new ServiceError(`App ${index + 1}: 'name' is required`, "INVALID_TEMPLATE", 400)
+  }
+  if (typeof slug !== "string" || !slug.trim()) {
+    throw new ServiceError(`App '${name}': 'slug' is required`, "INVALID_TEMPLATE", 400)
+  }
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(slug) || slug.endsWith("-")) {
+    throw new ServiceError(
+      `App '${name}': slug '${slug}' is invalid — use lowercase alphanumeric and hyphens`,
+      "INVALID_TEMPLATE",
+      400,
+    )
+  }
+
+  const sourceType = raw.source_type
+  if (sourceType !== undefined && sourceType !== "git" && sourceType !== "image") {
+    throw new ServiceError(`App '${name}': source_type must be 'git' or 'image'`, "INVALID_TEMPLATE", 400)
+  }
+
+  const env = raw.env
+  if (env !== undefined && (typeof env !== "object" || Array.isArray(env) || env === null)) {
+    throw new ServiceError(`App '${name}': env must be a key-value map`, "INVALID_TEMPLATE", 400)
+  }
+
+  const secrets = raw.secrets
+  if (secrets !== undefined) {
+    if (!Array.isArray(secrets)) {
+      throw new ServiceError(`App '${name}': secrets must be an array`, "INVALID_TEMPLATE", 400)
+    }
+    for (const s of secrets) {
+      if (typeof s !== "string" && (typeof s !== "object" || s === null || typeof (s as Record<string, unknown>).name !== "string")) {
+        throw new ServiceError(
+          `App '${name}': each secret must be a string or an object with a 'name' field`,
+          "INVALID_TEMPLATE",
+          400,
+        )
+      }
+    }
+  }
+
+  // Any unrecognised fields → serialised as canetteConfig YAML
+  const canetteFields: Record<string, unknown> = {}
+  for (const [key, val] of Object.entries(raw)) {
+    if (!APP_ROW_FIELDS.has(key)) canetteFields[key] = val
+  }
+  const canetteConfig =
+    Object.keys(canetteFields).length > 0 ? jsyaml.dump(canetteFields) : undefined
+
+  return {
+    name: (name as string).trim(),
+    slug: (slug as string).trim(),
+    sourceType: ((sourceType as string | undefined) ?? "git") as AppSourceType,
+    gitUrl: typeof raw.git_url === "string" ? raw.git_url : undefined,
+    gitBranch: typeof raw.git_branch === "string" ? raw.git_branch : undefined,
+    gitCredentialId: typeof raw.git_credential_id === "string" ? raw.git_credential_id : undefined,
+    appPath: typeof raw.app_path === "string" ? raw.app_path : undefined,
+    imageUrl: typeof raw.image_url === "string" ? raw.image_url : undefined,
+    imageTag: typeof raw.image_tag === "string" ? raw.image_tag : undefined,
+    port: typeof raw.port === "number" ? raw.port : undefined,
+    env: env as Record<string, string> | undefined,
+    secrets: secrets
+      ? (secrets as Array<string | { name: string; description?: string }>).map((s) =>
+          typeof s === "string" ? { name: s } : { name: s.name, description: s.description },
+        )
+      : undefined,
+    canetteConfig,
+  }
+}
+
+export async function parseTemplate(input: { yaml?: string; url?: string }): Promise<AppTemplate> {
+  let yamlContent: string
+
+  if (input.url) {
+    yamlContent = await fetchTemplateYaml(input.url)
+  } else if (input.yaml) {
+    if (input.yaml.length > MAX_TEMPLATE_SIZE) {
+      throw new ServiceError("Template exceeds the 50 KB limit", "TOO_LARGE", 400)
+    }
+    yamlContent = input.yaml
+  } else {
+    throw new ServiceError("Either 'yaml' or 'url' is required", "MISSING_INPUT", 400)
+  }
+
+  let doc: unknown
+  try {
+    doc = jsyaml.load(yamlContent)
+  } catch {
+    throw new ServiceError("Invalid YAML: could not parse template", "INVALID_YAML", 400)
+  }
+
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+    throw new ServiceError("Template must be a YAML object at the top level", "INVALID_TEMPLATE", 400)
+  }
+
+  const root = doc as Record<string, unknown>
+
+  if (typeof root.name !== "string" || !root.name.trim()) {
+    throw new ServiceError("Template 'name' is required", "INVALID_TEMPLATE", 400)
+  }
+
+  if (!Array.isArray(root.apps) || root.apps.length === 0) {
+    throw new ServiceError("Template must have an 'apps' array with at least one entry", "INVALID_TEMPLATE", 400)
+  }
+
+  const apps = root.apps.map((app, i) => {
+    if (typeof app !== "object" || app === null || Array.isArray(app)) {
+      throw new ServiceError(`App ${i + 1}: must be a YAML object`, "INVALID_TEMPLATE", 400)
+    }
+    return parseTemplateApp(app as Record<string, unknown>, i)
+  })
+
+  const slugsSeen = new Set<string>()
+  for (const app of apps) {
+    if (slugsSeen.has(app.slug)) {
+      throw new ServiceError(`Duplicate slug '${app.slug}' in template`, "INVALID_TEMPLATE", 400)
+    }
+    slugsSeen.add(app.slug)
+  }
+
+  return {
+    name: root.name.trim(),
+    description: typeof root.description === "string" ? root.description.trim() : undefined,
+    apps,
+  }
+}

--- a/apps/api/tests/services/templates.test.ts
+++ b/apps/api/tests/services/templates.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest"
+import { parseTemplate } from "../../src/services/templates"
+
+const VALID_TEMPLATE = `
+name: "Full-stack starter"
+description: "API + Postgres"
+apps:
+  - name: API
+    slug: api
+    source_type: git
+    git_url: https://github.com/org/api
+    git_branch: main
+    port: 3000
+    env:
+      DB_HOST: "{{apps.db.slug}}"
+    secrets:
+      - DB_PASSWORD
+    resources:
+      requests:
+        cpu: 100m
+
+  - name: Database
+    slug: db
+    source_type: image
+    image_url: postgres
+    image_tag: "16"
+    port: 5432
+`
+
+describe("services/templates — parseTemplate", () => {
+  it("parses a valid two-app template", async () => {
+    const result = await parseTemplate({ yaml: VALID_TEMPLATE })
+
+    expect(result.name).toBe("Full-stack starter")
+    expect(result.description).toBe("API + Postgres")
+    expect(result.apps).toHaveLength(2)
+
+    const [api, db] = result.apps
+    expect(api.name).toBe("API")
+    expect(api.slug).toBe("api")
+    expect(api.sourceType).toBe("git")
+    expect(api.gitUrl).toBe("https://github.com/org/api")
+    expect(api.gitBranch).toBe("main")
+    expect(api.port).toBe(3000)
+    expect(api.env).toEqual({ DB_HOST: "{{apps.db.slug}}" })
+    expect(api.secrets).toEqual([{ name: "DB_PASSWORD" }])
+    // resources go into canetteConfig
+    expect(api.canetteConfig).toContain("cpu: 100m")
+
+    expect(db.name).toBe("Database")
+    expect(db.slug).toBe("db")
+    expect(db.sourceType).toBe("image")
+    expect(db.imageUrl).toBe("postgres")
+    expect(db.imageTag).toBe("16")
+    expect(db.canetteConfig).toBeUndefined()
+  })
+
+  it("silently ignores unknown top-level fields", async () => {
+    const yaml = `
+name: test
+unknown_future_field: ignored
+apps:
+  - name: App
+    slug: app
+    source_type: git
+    git_url: https://github.com/org/repo
+`
+    const result = await parseTemplate({ yaml })
+    expect(result.apps).toHaveLength(1)
+  })
+
+  it("silently ignores unknown app-level fields via canetteConfig passthrough", async () => {
+    const yaml = `
+name: test
+apps:
+  - name: App
+    slug: app
+    source_type: git
+    git_url: https://github.com/org/repo
+    some_future_field: value
+`
+    const result = await parseTemplate({ yaml })
+    expect(result.apps[0].canetteConfig).toContain("some_future_field")
+  })
+
+  it("defaults source_type to git when omitted", async () => {
+    const yaml = `
+name: test
+apps:
+  - name: App
+    slug: app
+    git_url: https://github.com/org/repo
+`
+    const result = await parseTemplate({ yaml })
+    expect(result.apps[0].sourceType).toBe("git")
+  })
+
+  it("rejects missing template name", async () => {
+    const yaml = `
+apps:
+  - name: App
+    slug: app
+    source_type: git
+    git_url: https://github.com/org/repo
+`
+    await expect(parseTemplate({ yaml })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
+    })
+  })
+
+  it("rejects empty apps array", async () => {
+    const yaml = `name: test\napps: []`
+    await expect(parseTemplate({ yaml })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
+    })
+  })
+
+  it("rejects app with missing slug", async () => {
+    const yaml = `
+name: test
+apps:
+  - name: App
+    source_type: git
+`
+    await expect(parseTemplate({ yaml })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
+    })
+  })
+
+  it("rejects app with invalid slug format", async () => {
+    const yaml = `
+name: test
+apps:
+  - name: App
+    slug: Bad_Slug!
+    source_type: git
+`
+    await expect(parseTemplate({ yaml })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
+    })
+  })
+
+  it("rejects duplicate slugs within a template", async () => {
+    const yaml = `
+name: test
+apps:
+  - name: App 1
+    slug: app
+    source_type: git
+  - name: App 2
+    slug: app
+    source_type: image
+    image_url: nginx
+`
+    await expect(parseTemplate({ yaml })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
+    })
+  })
+
+  it("rejects invalid YAML", async () => {
+    await expect(parseTemplate({ yaml: ": : : bad yaml !!!" })).rejects.toMatchObject({
+      code: "INVALID_YAML",
+    })
+  })
+
+  it("rejects missing input", async () => {
+    await expect(parseTemplate({})).rejects.toMatchObject({
+      code: "MISSING_INPUT",
+    })
+  })
+
+  it("blocks private/loopback URLs", async () => {
+    for (const url of [
+      "http://localhost/template.yaml",
+      "http://127.0.0.1/template.yaml",
+      "http://10.0.0.1/template.yaml",
+      "http://192.168.1.1/template.yaml",
+      "http://172.16.0.1/template.yaml",
+    ]) {
+      await expect(parseTemplate({ url })).rejects.toMatchObject({
+        code: "FORBIDDEN_URL",
+      })
+    }
+  })
+
+  it("blocks non-http(s) URLs", async () => {
+    await expect(parseTemplate({ url: "file:///etc/passwd" })).rejects.toMatchObject({
+      code: "INVALID_URL",
+    })
+  })
+})

--- a/apps/api/tests/services/templates.test.ts
+++ b/apps/api/tests/services/templates.test.ts
@@ -163,29 +163,9 @@ apps:
     })
   })
 
-  it("rejects missing input", async () => {
-    await expect(parseTemplate({})).rejects.toMatchObject({
-      code: "MISSING_INPUT",
-    })
-  })
-
-  it("blocks private/loopback URLs", async () => {
-    for (const url of [
-      "http://localhost/template.yaml",
-      "http://127.0.0.1/template.yaml",
-      "http://10.0.0.1/template.yaml",
-      "http://192.168.1.1/template.yaml",
-      "http://172.16.0.1/template.yaml",
-    ]) {
-      await expect(parseTemplate({ url })).rejects.toMatchObject({
-        code: "FORBIDDEN_URL",
-      })
-    }
-  })
-
-  it("blocks non-http(s) URLs", async () => {
-    await expect(parseTemplate({ url: "file:///etc/passwd" })).rejects.toMatchObject({
-      code: "INVALID_URL",
+  it("rejects empty yaml", async () => {
+    await expect(parseTemplate({ yaml: "" })).rejects.toMatchObject({
+      code: "INVALID_TEMPLATE",
     })
   })
 })

--- a/apps/docs/content/docs/configuration/meta.json
+++ b/apps/docs/content/docs/configuration/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Configuration",
-  "pages": ["canette-yaml", "secrets", "git-credentials", "github-app", "authentication"]
+  "pages": ["canette-yaml", "templates", "secrets", "git-credentials", "github-app", "authentication"]
 }

--- a/apps/docs/content/docs/configuration/templates.mdx
+++ b/apps/docs/content/docs/configuration/templates.mdx
@@ -1,0 +1,232 @@
+---
+title: Templates
+description: Use a canette-template.yaml file to create one or more apps at once from a single file.
+---
+
+A **template** is a YAML file that describes one or more apps to create in a project. It is the fastest way to get a full stack running — paste the file or give canette a URL, review the settings in the wizard, and all apps are created in one go.
+
+## Loading a template
+
+1. Open a project in the dashboard.
+2. Click **From template** next to the **New app** button.
+3. Paste the YAML directly, or enter a public URL (e.g. a raw GitHub link). The file is fetched server-side.
+4. Step through the wizard — one screen per app — to review or adjust any field.
+5. Click **Create _N_ apps** on the summary screen.
+
+## File format
+
+A template file is a superset of [`canette.yaml`](/docs/configuration/canette-yaml). It adds a top-level `name`, an optional `description`, and an `apps` array. Each entry in `apps` is a single-app configuration.
+
+```yaml
+name: "Template display name"    # required
+description: "Optional subtitle"
+
+apps:
+  - name: My App                 # display name — required
+    slug: my-app                 # suggested slug — required, lowercase alphanumeric + hyphens
+
+    # Source: git repo or Docker image
+    source_type: git             # "git" (default) or "image"
+    git_url: https://github.com/org/repo
+    git_branch: main             # optional, defaults to "main"
+    app_path: ""                 # optional, subdirectory within the repo
+
+    # Or for a Docker image:
+    # source_type: image
+    # image_url: nginx
+    # image_tag: latest
+
+    port: 3000
+
+    # Env vars (plaintext, shown and editable in the wizard)
+    env:
+      KEY: value
+
+    # Secret names only — the wizard prompts for values.
+    # Optionally add a description to guide whoever fills in the value.
+    secrets:
+      - SECRET_NAME
+      - name: ANNOTATED_SECRET
+        description: "A 32-character random string — run: openssl rand -hex 16"
+
+    # Any canette.yaml runtime fields are accepted here too:
+    # runtime, resources, replicas, healthcheck, ingress, build
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+```
+
+### Cross-app references
+
+When one app's env var needs to reference another app's slug (for example, a service hostname), use the `{{apps.<slug>.slug}}` syntax:
+
+```yaml
+env:
+  DB_HOST: "{{apps.db.slug}}"
+```
+
+The wizard shows a live preview of the resolved value as you type. At creation time, all references are substituted with the slugs the user confirmed in the wizard.
+
+## Field notes
+
+- **`name`** and **`slug`** are the only required fields per app.
+- **`slug`** is a suggestion — the wizard pre-fills it and lets you edit. If a slug is already taken in the project you will be asked to choose another.
+- **Env vars** are shown in the wizard as editable key-value pairs. Values containing `{{apps.X.slug}}` show a resolved preview.
+- **Secrets** listed under `secrets` appear as required password fields in the wizard. Values are encrypted at rest and are never returned by the API. Each entry can be a plain string or an object with `name` and an optional `description` shown as hint text in the wizard.
+- Any field not recognised as an app-row field (`source_type`, `git_url`, etc.) is passed through as `canette.yaml` content and stored as the app's advanced configuration. Unknown fields are silently ignored for forward compatibility.
+
+---
+
+## Examples
+
+### Minimal — single Git app
+
+The simplest possible template. Good for sharing a repo with a one-click deploy link.
+
+```yaml
+name: "Hello World"
+
+apps:
+  - name: Hello World
+    slug: hello-world
+    source_type: git
+    git_url: https://github.com/org/hello-world
+    port: 3000
+```
+
+---
+
+### Single Docker image
+
+Deploy a pre-built image straight from a registry.
+
+```yaml
+name: "Nginx static site"
+
+apps:
+  - name: Web
+    slug: web
+    source_type: image
+    image_url: nginx
+    image_tag: "1.27"
+    port: 80
+```
+
+---
+
+### Node.js API + Postgres
+
+A two-app stack where the API connects to the database over the cluster-internal hostname.
+
+```yaml
+name: "Node API + Postgres"
+description: "Express API backed by a Postgres database"
+
+apps:
+  - name: API
+    slug: api
+    source_type: git
+    git_url: https://github.com/org/api
+    git_branch: main
+    port: 3000
+    env:
+      DATABASE_URL: "postgresql://app:{{apps.db.slug}}@{{apps.db.slug}}:5432/app"
+      NODE_ENV: production
+    secrets:
+      - name: SESSION_SECRET
+        description: "A 32-character random string — run: openssl rand -hex 16"
+
+  - name: Postgres
+    slug: db
+    source_type: image
+    image_url: postgres
+    image_tag: "16"
+    port: 5432
+    secrets:
+      - name: POSTGRES_PASSWORD
+        description: "Choose a strong password — must match DATABASE_URL above"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
+
+> The `{{apps.db.slug}}` references in `DATABASE_URL` are resolved to the slug you confirm for the Postgres app in the wizard.
+
+---
+
+### Full-stack with resource limits and health checks
+
+Demonstrates most template fields at once.
+
+```yaml
+name: "Full-stack starter"
+description: "Next.js frontend, Go API, and Postgres"
+
+apps:
+  - name: Frontend
+    slug: frontend
+    source_type: git
+    git_url: https://github.com/org/frontend
+    git_branch: main
+    port: 3000
+    env:
+      NEXT_PUBLIC_API_URL: "http://{{apps.api.slug}}:4000"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    healthcheck:
+      path: /
+      port: 3000
+      initial_delay: 15
+      period: 30
+
+  - name: API
+    slug: api
+    source_type: git
+    git_url: https://github.com/org/api
+    git_branch: main
+    port: 4000
+    env:
+      DATABASE_URL: "postgresql://app:secret@{{apps.db.slug}}:5432/app"
+      ENVIRONMENT: production
+    secrets:
+      - JWT_SECRET
+      - DATABASE_PASSWORD
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi
+    healthcheck:
+      path: /healthz
+      port: 4000
+      initial_delay: 10
+      period: 15
+
+  - name: Postgres
+    slug: db
+    source_type: image
+    image_url: postgres
+    image_tag: "16"
+    port: 5432
+    secrets:
+      - POSTGRES_PASSWORD
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+```

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/new/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/apps/new/page.tsx
@@ -1,58 +1,23 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card"
-import { cn } from "@/lib/utils"
-import { HelpTooltip } from "@/components/ui/tooltip"
-import { CredentialSelect } from "@/components/credential-select"
+import { FormError } from "@/components/ui/form-error"
+import { AppFormFields, defaultAppFormValue, isValidEnvKey } from "@/components/app-form-fields"
+import type { AppFormValue } from "@/components/app-form-fields"
 import * as api from "@/lib/api"
 import type { GitCredential, Project } from "@canette/types"
-
-function parseGitUrl(raw: string): { gitUrl: string; branch: string; appPath: string } | null {
-  // GitHub: https://github.com/org/repo/tree/branch[/path]
-  const gh = raw.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)\/tree\/([^/]+)(\/.*)?$/)
-  if (gh) return { gitUrl: gh[1], branch: gh[2], appPath: gh[3] ?? "" }
-  // GitLab: https://gitlab.com/org/repo/-/tree/branch[/path]
-  const gl = raw.match(/^(https:\/\/gitlab\.com\/[^/]+\/[^/]+)\/-\/tree\/([^/]+)(\/.*)?$/)
-  if (gl) return { gitUrl: gl[1], branch: gl[2], appPath: gl[3] ?? "" }
-  return null
-}
-
-function toSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 63)
-}
-
-type SlugState = "idle" | "checking" | "available" | "taken" | "invalid"
 
 export default function NewAppPage() {
   const { slug: projectSlug } = useParams<{ slug: string }>()
   const router = useRouter()
   const [project, setProject] = useState<Project | null>(null)
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
-  const [slugEdited, setSlugEdited] = useState(false)
-  const [slugState, setSlugState] = useState<SlugState>("idle")
-  const [sourceType, setSourceType] = useState<"git" | "image">("git")
-  const [gitUrl, setGitUrl] = useState("")
-  const [gitBranch, setGitBranch] = useState("main")
-  const [appPath, setAppPath] = useState("")
-  const [urlParsed, setUrlParsed] = useState(false)
-  const [imageUrl, setImageUrl] = useState("")
-  const [imageTag, setImageTag] = useState("latest")
-  const [port, setPort] = useState(3000)
-  const [gitCredentialId, setGitCredentialId] = useState<string>("")
   const [credentials, setCredentials] = useState<GitCredential[]>([])
+  const [form, setForm] = useState<AppFormValue>(defaultAppFormValue)
   const [error, setError] = useState("")
   const [submitting, setSubmitting] = useState(false)
-  const checkTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     api.projects.get(projectSlug)
@@ -61,60 +26,36 @@ export default function NewAppPage() {
     api.projects.listCredentials(projectSlug).then(setCredentials).catch(() => {})
   }, [projectSlug])
 
-  useEffect(() => {
-    if (!slugEdited) setSlug(toSlug(name))
-  }, [name, slugEdited])
-
-  useEffect(() => {
-    if (!project) return
-    if (checkTimer.current) clearTimeout(checkTimer.current)
-    if (!slug) { setSlugState("idle"); return }
-
-    const valid = /^[a-z0-9][a-z0-9-]{0,62}$/.test(slug) && !slug.endsWith("-")
-    if (!valid) { setSlugState("invalid"); return }
-
-    setSlugState("checking")
-    checkTimer.current = setTimeout(async () => {
-      try {
-        const res = await fetch(
-          `/api/v1/projects/${project.id}/apps/slug-available?slug=${encodeURIComponent(slug)}`,
-          { credentials: "include" },
-        )
-        const data = await res.json()
-        setSlugState(data.available ? "available" : "taken")
-      } catch {
-        setSlugState("idle")
-      }
-    }, 400)
-
-    return () => { if (checkTimer.current) clearTimeout(checkTimer.current) }
-  }, [slug, project])
+  function handleChange(patch: Partial<AppFormValue>) {
+    setForm((prev) => ({ ...prev, ...patch }))
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!project || slugState !== "available") return
+    if (!project || form.slugState !== "available") return
     setError("")
     setSubmitting(true)
 
     try {
-      const body =
-        sourceType === "git"
+      const port = parseInt(form.port, 10)
+      const appBody =
+        form.sourceType === "git"
           ? {
-              name: name.trim(),
-              slug,
-              sourceType,
-              gitUrl: gitUrl.trim(),
-              gitBranch: gitBranch.trim() || "main",
-              appPath: appPath.trim() || undefined,
-              gitCredentialId: gitCredentialId || undefined,
+              name: form.name.trim(),
+              slug: form.slug,
+              sourceType: "git" as const,
+              gitUrl: form.gitUrl.trim(),
+              gitBranch: form.gitBranch.trim() || "main",
+              appPath: form.appPath.trim() || undefined,
+              gitCredentialId: form.gitCredentialId || undefined,
               port,
             }
           : {
-              name: name.trim(),
-              slug,
-              sourceType,
-              imageUrl: imageUrl.trim(),
-              imageTag: imageTag.trim() || "latest",
+              name: form.name.trim(),
+              slug: form.slug,
+              sourceType: "image" as const,
+              imageUrl: form.imageUrl.trim(),
+              imageTag: form.imageTag.trim() || "latest",
               port,
             }
 
@@ -122,30 +63,31 @@ export default function NewAppPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify(body),
+        body: JSON.stringify(appBody),
       })
       const data = await res.json()
       if (!res.ok) { setError(data.error ?? "Something went wrong"); return }
+
+      for (const { key, value, isSecret } of form.envRows) {
+        if (!key.trim()) continue
+        if (isSecret) {
+          await api.env.putSecret(data.id, key.trim(), value)
+        } else {
+          await api.env.putVar(data.id, key.trim(), value)
+        }
+      }
+
       router.push(`/dashboard/projects/${projectSlug}/apps/${data.slug}`)
-    } catch {
-      setError("Network error — please try again")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error — please try again")
     } finally {
       setSubmitting(false)
     }
   }
 
-  const slugHint = {
-    idle: null,
-    checking: <span className="text-muted-foreground">Checking…</span>,
-    available: <span className="text-green-500">Available</span>,
-    taken: <span className="text-destructive">Already taken in this project</span>,
-    invalid: <span className="text-destructive">Lowercase letters, numbers and hyphens only; cannot start or end with a hyphen</span>,
-  }[slugState]
-
-  const sourceReady =
-    sourceType === "git" ? !!gitUrl.trim() : !!imageUrl.trim()
-
-  const canSubmit = !!name.trim() && sourceReady && slugState === "available" && !!project && !submitting
+  const sourceReady = form.sourceType === "git" ? !!form.gitUrl.trim() : !!form.imageUrl.trim()
+  const envKeysValid = form.envRows.every((r) => !r.key.trim() || isValidEnvKey(r.key.trim()))
+  const canSubmit = !!form.name.trim() && sourceReady && form.slugState === "available" && envKeysValid && !!project && !submitting
 
   return (
     <div>
@@ -155,193 +97,35 @@ export default function NewAppPage() {
           <CardDescription>Connect a Git repository or Docker image to deploy.</CardDescription>
         </CardHeader>
         <CardContent>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-5">
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="name">Name</Label>
-                <Input
-                  id="name"
-                  placeholder="My App"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  autoFocus
-                  required
-                />
-              </div>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+            {project && (
+              <AppFormFields
+                value={form}
+                onChange={handleChange}
+                projectId={project.id}
+                credentials={credentials}
+                teamId={project.teamId}
+                parseGitUrl
+                autoSlug
+                autoFocus
+              />
+            )}
 
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="slug">
-                  Slug
-                  <span className="ml-2 text-xs text-muted-foreground font-normal">(used as container name)</span>
-                </Label>
-                <Input
-                  id="slug"
-                  placeholder="my-app"
-                  value={slug}
-                  onChange={(e) => { setSlug(e.target.value); setSlugEdited(true) }}
-                  className={cn(
-                    slugState === "taken" || slugState === "invalid" ? "border-destructive" : "",
-                    slugState === "available" ? "border-green-500" : "",
-                  )}
-                />
-                <p className="text-xs min-h-[1rem]">{slugHint}</p>
-              </div>
+            {error && <FormError message={error} />}
 
-              {/* Source type toggle */}
-              <div className="flex flex-col gap-1.5">
-                <Label>Source</Label>
-                <div className="flex rounded-md border border-border overflow-hidden w-fit">
-                  <button
-                    type="button"
-                    onClick={() => setSourceType("git")}
-                    className={cn(
-                      "px-4 py-1.5 text-sm transition-colors",
-                      sourceType === "git"
-                        ? "bg-foreground text-background font-medium"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                    )}
-                  >
-                    Git
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setSourceType("image")}
-                    className={cn(
-                      "px-4 py-1.5 text-sm transition-colors border-l border-border",
-                      sourceType === "image"
-                        ? "bg-foreground text-background font-medium"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                    )}
-                  >
-                    Docker Image
-                  </button>
-                </div>
-              </div>
-
-              {sourceType === "git" ? (
-                <>
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="gitUrl">Git URL</Label>
-                    <Input
-                      id="gitUrl"
-                      placeholder="https://github.com/org/repo"
-                      value={gitUrl}
-                      onChange={(e) => {
-                        const parsed = parseGitUrl(e.target.value)
-                        if (parsed) {
-                          setGitUrl(parsed.gitUrl)
-                          setGitBranch(parsed.branch)
-                          setAppPath(parsed.appPath)
-                          setUrlParsed(true)
-                        } else {
-                          setGitUrl(e.target.value)
-                          setUrlParsed(false)
-                        }
-                      }}
-                      required
-                    />
-                    {urlParsed && (
-                      <p className="text-xs text-muted-foreground">
-                        Branch and app path were detected from the URL.
-                      </p>
-                    )}
-                  </div>
-
-                  <CredentialSelect
-                    credentials={credentials}
-                    value={gitCredentialId}
-                    onChange={setGitCredentialId}
-                    teamId={project?.teamId}
-                    gitUrl={gitUrl}
-                  />
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="flex flex-col gap-1.5">
-                      <Label htmlFor="gitBranch">Branch</Label>
-                      <Input
-                        id="gitBranch"
-                        placeholder="main"
-                        value={gitBranch}
-                        onChange={(e) => setGitBranch(e.target.value)}
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <Label htmlFor="appPath">
-                        App path
-                        <span className="ml-2 text-xs text-muted-foreground font-normal">optional</span>
-                      </Label>
-                      <Input
-                        id="appPath"
-                        placeholder="/"
-                        value={appPath}
-                        onChange={(e) => setAppPath(e.target.value)}
-                      />
-                    </div>
-                  </div>
-                </>
-              ) : (
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="imageUrl">Image</Label>
-                    <Input
-                      id="imageUrl"
-                      placeholder="nginx"
-                      value={imageUrl}
-                      onChange={(e) => setImageUrl(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="imageTag">Tag</Label>
-                    <Input
-                      id="imageTag"
-                      placeholder="latest"
-                      value={imageTag}
-                      onChange={(e) => setImageTag(e.target.value)}
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="port" className="flex items-center gap-1">
-                  Port
-                  <HelpTooltip>
-                    <p className="mb-1.5">The same port your app uses locally, e.g. <code className="font-mono">http://localhost:3000</code> → port 3000.</p>
-                    <p className="mb-1 font-medium">Common defaults:</p>
-                    <ul className="space-y-0.5 text-muted-foreground">
-                      <li>Next.js / Node / Rails → 3000</li>
-                      <li>Vite → 5173</li>
-                      <li>Django / Laravel → 8000</li>
-                      <li>Flask / FastAPI → 5000</li>
-                      <li>Spring Boot → 8080</li>
-                    </ul>
-                    <p className="mt-1.5 text-muted-foreground">
-                      For Git apps, <code className="font-mono">PORT</code> is added automatically to the deployment. Most apps should work with the default value.
-                    </p>
-                  </HelpTooltip>
-                </Label>
-                <Input
-                  id="port"
-                  type="number"
-                  min={1}
-                  max={65535}
-                  value={port}
-                  onChange={(e) => setPort(Number(e.target.value))}
-                  className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                />
-              </div>
-
-              {error && <p className="text-sm text-destructive">{error}</p>}
-
-              <div className="flex justify-end gap-3 pt-1">
-                <Button type="button" variant="ghost" onClick={() => router.push(`/dashboard/projects/${projectSlug}`)}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={!canSubmit}>
-                  {submitting ? "Adding…" : "Add app"}
-                </Button>
-              </div>
-            </form>
+            <div className="flex justify-end gap-3 pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => router.push(`/dashboard/projects/${projectSlug}`)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!canSubmit}>
+                {submitting ? "Adding…" : "Add app"}
+              </Button>
+            </div>
+          </form>
         </CardContent>
       </Card>
     </div>

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
@@ -1,53 +1,32 @@
 "use client"
 
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardHeader, CardDescription } from "@/components/ui/card"
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible"
 import { FormError } from "@/components/ui/form-error"
-import { CredentialSelect } from "@/components/credential-select"
+import { AppFormFields, toSlug, isValidEnvKey } from "@/components/app-form-fields"
+import type { AppFormValue } from "@/components/app-form-fields"
 import { cn } from "@/lib/utils"
 import * as api from "@/lib/api"
-import { resolveTemplateVars, hasTemplateVars, buildSlugMap } from "@/lib/template"
+import { resolveTemplateVars, buildSlugMap } from "@/lib/template"
 import type { AppTemplate, GitCredential, Project } from "@canette/types"
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-type SlugState = "idle" | "checking" | "available" | "taken" | "invalid"
-
-type AppFormState = {
-  originalSlug: string
-  name: string
-  slug: string
-  slugState: SlugState
-  sourceType: "git" | "image"
-  gitUrl: string
-  gitBranch: string
-  appPath: string
-  imageUrl: string
-  imageTag: string
-  port: string
-  gitCredentialId: string
-  envRows: Array<{ key: string; value: string }>
-  secretValues: Record<string, string>
-  canetteConfig: string
-}
 
 type CreationStatus = "pending" | "creating" | "done" | "error"
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function toSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 63)
-}
-
-function formStateFromTemplate(app: AppTemplate["apps"][number]): AppFormState {
+function formValueFromTemplate(app: AppTemplate["apps"][number]): AppFormValue {
+  const envRows = [
+    ...Object.entries(app.env ?? {}).map(([key, value]) => ({ key, value, isSecret: false })),
+    ...(app.secrets ?? []).map((s) => ({ key: s.name, value: "", isSecret: true, description: s.description })),
+  ]
   return {
-    originalSlug: app.slug,
     name: app.name,
     slug: app.slug,
     slugState: "idle",
@@ -59,10 +38,7 @@ function formStateFromTemplate(app: AppTemplate["apps"][number]): AppFormState {
     imageTag: app.imageTag ?? "latest",
     port: app.port?.toString() ?? "3000",
     gitCredentialId: app.gitCredentialId ?? "",
-    envRows: app.env
-      ? Object.entries(app.env).map(([key, value]) => ({ key, value }))
-      : [],
-    secretValues: Object.fromEntries((app.secrets ?? []).map((s) => [s.name, ""])),
+    envRows,
     canetteConfig: app.canetteConfig ?? "",
   }
 }
@@ -76,78 +52,42 @@ export default function FromTemplatePage() {
   const [project, setProject] = useState<Project | null>(null)
   const [credentials, setCredentials] = useState<GitCredential[]>([])
 
-  // step: -1 = load, 0..N-1 = per-app, N = summary
-  const [step, setStep] = useState(-1)
+  // Template load state
+  const [loaded, setLoaded] = useState(false)
   const [template, setTemplate] = useState<AppTemplate | null>(null)
-  const [appForms, setAppForms] = useState<AppFormState[]>([])
+  const [originalSlugs, setOriginalSlugs] = useState<string[]>([])
+  const [appForms, setAppForms] = useState<AppFormValue[]>([])
 
+  // Load form state
   const [loadInput, setLoadInput] = useState("paste")
   const [yamlText, setYamlText] = useState("")
   const [urlText, setUrlText] = useState("")
   const [loadError, setLoadError] = useState("")
   const [loading, setLoading] = useState(false)
 
+  // Creation state
   const [creationStatuses, setCreationStatuses] = useState<CreationStatus[]>([])
   const [creationErrors, setCreationErrors] = useState<string[]>([])
   const [creating, setCreating] = useState(false)
 
-  const slugTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
   useEffect(() => {
-    api.projects.get(projectSlug)
-      .then(setProject)
-      .catch(() => {})
+    api.projects.get(projectSlug).then(setProject).catch(() => {})
     api.projects.listCredentials(projectSlug).then(setCredentials).catch(() => {})
   }, [projectSlug])
 
-  // ── Slug live-check for the active app step ─────────────────────────────────
+  // ── Helpers ─────────────────────────────────────────────────────────────────
 
-  const runSlugCheck = useCallback(
-    (appIndex: number, slug: string) => {
-      if (!project) return
-      if (slugTimerRef.current) clearTimeout(slugTimerRef.current)
-
-      if (!slug) {
-        updateApp(appIndex, { slugState: "idle" })
-        return
-      }
-      const valid = /^[a-z0-9][a-z0-9-]{0,62}$/.test(slug) && !slug.endsWith("-")
-      if (!valid) {
-        updateApp(appIndex, { slugState: "invalid" })
-        return
-      }
-
-      updateApp(appIndex, { slugState: "checking" })
-      slugTimerRef.current = setTimeout(async () => {
-        try {
-          const res = await fetch(
-            `/api/v1/projects/${project.id}/apps/slug-available?slug=${encodeURIComponent(slug)}`,
-            { credentials: "include" },
-          )
-          const data = await res.json()
-          updateApp(appIndex, { slugState: data.available ? "available" : "taken" })
-        } catch {
-          updateApp(appIndex, { slugState: "idle" })
-        }
-      }, 400)
-    },
-    [project],
-  )
-
-  // Re-run check when project loads for the active step
-  useEffect(() => {
-    if (step >= 0 && step < appForms.length && project) {
-      runSlugCheck(step, appForms[step].slug)
-    }
-  }, [step, project]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // ── State helpers ───────────────────────────────────────────────────────────
-
-  function updateApp(index: number, patch: Partial<AppFormState>) {
+  function updateApp(index: number, patch: Partial<AppFormValue>) {
     setAppForms((prev) => prev.map((f, i) => (i === index ? { ...f, ...patch } : f)))
   }
 
-  // ── Load template ───────────────────────────────────────────────────────────
+  function currentSlugMap(): Record<string, string> {
+    return buildSlugMap(
+      appForms.map((f, i) => ({ originalSlug: originalSlugs[i] ?? f.slug, chosenSlug: f.slug })),
+    )
+  }
+
+  // ── Load template ────────────────────────────────────────────────────────────
 
   async function handleLoad() {
     setLoadError("")
@@ -160,10 +100,11 @@ export default function FromTemplatePage() {
       }
       const parsed = await api.templates.parse(body)
       setTemplate(parsed)
-      setAppForms(parsed.apps.map(formStateFromTemplate))
+      setOriginalSlugs(parsed.apps.map((a) => a.slug))
+      setAppForms(parsed.apps.map(formValueFromTemplate))
       setCreationStatuses(parsed.apps.map(() => "pending"))
       setCreationErrors(parsed.apps.map(() => ""))
-      setStep(0)
+      setLoaded(true)
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : "Failed to load template")
     } finally {
@@ -171,78 +112,37 @@ export default function FromTemplatePage() {
     }
   }
 
-  // ── Per-app field handlers ───────────────────────────────────────────────────
-
-  function handleSlugChange(index: number, value: string) {
-    updateApp(index, { slug: value })
-    runSlugCheck(index, value)
-  }
+  // ── Per-app name change (mirrors name → slug auto-gen from template slug) ───
 
   function handleNameChange(index: number, value: string) {
     const form = appForms[index]
-    const auto = toSlug(form.name) === form.slug
-    updateApp(index, { name: value, ...(auto ? { slug: toSlug(value) } : {}) })
-    if (auto) runSlugCheck(index, toSlug(value))
+    const wasAutoSlug = toSlug(form.name) === form.slug
+    updateApp(index, { name: value, ...(wasAutoSlug ? { slug: toSlug(value) } : {}) })
   }
 
-  // ── Env row helpers ──────────────────────────────────────────────────────────
+  // ── Validation ────────────────────────────────────────────────────────────────
 
-  function addEnvRow(index: number) {
-    updateApp(index, {
-      envRows: [...appForms[index].envRows, { key: "", value: "" }],
+  function allAppsValid(): boolean {
+    return appForms.every((form) => {
+      if (!form.name.trim()) return false
+      if (form.slugState !== "available") return false
+      if (form.sourceType === "git" && !form.gitUrl.trim()) return false
+      if (form.sourceType === "image" && !form.imageUrl.trim()) return false
+      const port = parseInt(form.port, 10)
+      if (isNaN(port) || port < 1 || port > 65535) return false
+      if (form.envRows.some((r) => r.key.trim() && !isValidEnvKey(r.key.trim()))) return false
+      return true
     })
   }
 
-  function updateEnvRow(
-    appIndex: number,
-    rowIndex: number,
-    field: "key" | "value",
-    value: string,
-  ) {
-    const rows = appForms[appIndex].envRows.map((r, i) =>
-      i === rowIndex ? { ...r, [field]: value } : r,
-    )
-    updateApp(appIndex, { envRows: rows })
-  }
-
-  function removeEnvRow(appIndex: number, rowIndex: number) {
-    updateApp(appIndex, {
-      envRows: appForms[appIndex].envRows.filter((_, i) => i !== rowIndex),
-    })
-  }
-
-  // ── Current slug map (for template var preview) ──────────────────────────────
-
-  function currentSlugMap(): Record<string, string> {
-    return buildSlugMap(
-      appForms.map((f) => ({ originalSlug: f.originalSlug, chosenSlug: f.slug })),
-    )
-  }
-
-  // ── Validation for the current step ─────────────────────────────────────────
-
-  function currentStepValid(): boolean {
-    if (step < 0 || step >= appForms.length) return true
-    const form = appForms[step]
-    if (!form.name.trim()) return false
-    if (form.slugState !== "available") return false
-    if (form.sourceType === "git" && !form.gitUrl.trim()) return false
-    if (form.sourceType === "image" && !form.imageUrl.trim()) return false
-    const port = parseInt(form.port, 10)
-    if (isNaN(port) || port < 1 || port > 65535) return false
-    const missingSecrets = Object.entries(form.secretValues).filter(([, v]) => !v)
-    if (missingSecrets.length > 0) return false
-    return true
-  }
-
-  // ── Create all apps ──────────────────────────────────────────────────────────
+  // ── Create all apps ───────────────────────────────────────────────────────────
 
   async function handleCreate() {
     if (!project) return
     setCreating(true)
 
     const slugMap = buildSlugMap(
-      appForms.map((f) => ({ originalSlug: f.originalSlug, chosenSlug: f.slug })),
+      appForms.map((f, i) => ({ originalSlug: originalSlugs[i] ?? f.slug, chosenSlug: f.slug })),
     )
 
     for (let i = 0; i < appForms.length; i++) {
@@ -276,16 +176,13 @@ export default function FromTemplatePage() {
 
         const created = await api.apps.create(project.id, appBody)
 
-        // Set env vars (resolve cross-app references)
-        for (const { key, value } of form.envRows) {
+        for (const { key, value, isSecret } of form.envRows) {
           if (!key.trim()) continue
-          const resolved = resolveTemplateVars(value, slugMap)
-          await api.env.putVar(created.id, key.trim(), resolved)
-        }
-
-        // Set secrets
-        for (const [key, value] of Object.entries(form.secretValues)) {
-          if (value) await api.env.putSecret(created.id, key, value)
+          if (isSecret) {
+            await api.env.putSecret(created.id, key.trim(), value)
+          } else {
+            await api.env.putVar(created.id, key.trim(), resolveTemplateVars(value, slugMap))
+          }
         }
 
         setCreationStatuses((prev) => prev.map((s, idx) => (idx === i ? "done" : s)))
@@ -302,23 +199,9 @@ export default function FromTemplatePage() {
     router.push(`/dashboard/projects/${projectSlug}`)
   }
 
-  // ── Render helpers ────────────────────────────────────────────────────────────
+  // ── Render: Load template ─────────────────────────────────────────────────────
 
-  function slugHint(state: SlugState) {
-    return {
-      idle: null,
-      checking: <span className="text-muted-foreground">Checking…</span>,
-      available: <span className="text-green-500">Available</span>,
-      taken: <span className="text-destructive">Already taken in this project</span>,
-      invalid: <span className="text-destructive">Lowercase letters, numbers and hyphens only</span>,
-    }[state]
-  }
-
-  const totalApps = appForms.length
-
-  // ── Step: Load ───────────────────────────────────────────────────────────────
-
-  if (step === -1) {
+  if (!loaded) {
     return (
       <div>
         <h1 className="text-xl font-semibold mb-6">From template</h1>
@@ -382,12 +265,12 @@ export default function FromTemplatePage() {
 
             {loadError && <FormError message={loadError} />}
 
-            <div className="flex gap-3">
-              <Button onClick={handleLoad} disabled={loading}>
-                {loading ? "Loading…" : "Load template"}
-              </Button>
+            <div className="flex justify-end gap-3">
               <Button variant="ghost" asChild>
                 <a href={`/dashboard/projects/${projectSlug}`}>Cancel</a>
+              </Button>
+              <Button onClick={handleLoad} disabled={loading}>
+                {loading ? "Loading…" : "Load template"}
               </Button>
             </div>
           </CardContent>
@@ -396,349 +279,83 @@ export default function FromTemplatePage() {
     )
   }
 
-  // ── Step: Summary / Create ────────────────────────────────────────────────────
+  // ── Render: App configuration ─────────────────────────────────────────────────
 
-  if (step === totalApps) {
-    const allDone = creationStatuses.every((s) => s === "done")
-
-    return (
-      <div>
-        <h1 className="text-xl font-semibold mb-2">Review and create</h1>
-        <p className="text-sm text-muted-foreground mb-6">
-          {template?.name} — {totalApps} app{totalApps !== 1 ? "s" : ""} will be added to this project.
-        </p>
-
-        <div className="flex flex-col gap-3 max-w-2xl mb-6">
-          {appForms.map((form, i) => {
-            const status = creationStatuses[i]
-            return (
-              <Card key={i}>
-                <CardContent className="flex items-center justify-between gap-3 py-4">
-                  <div className="flex flex-col gap-0.5 min-w-0">
-                    <p className="text-sm font-medium truncate">{form.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">{form.slug}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {form.sourceType === "git" ? form.gitUrl || "—" : `${form.imageUrl}:${form.imageTag}`}
-                    </p>
-                    {(() => {
-                      const envCount = form.envRows.filter(r => r.key).length
-                      const secretCount = Object.keys(form.secretValues).length
-                      const parts = []
-                      if (envCount > 0) parts.push(`${envCount} env var${envCount !== 1 ? "s" : ""}`)
-                      if (secretCount > 0) parts.push(`${secretCount} secret${secretCount !== 1 ? "s" : ""}`)
-                      return parts.length > 0
-                        ? <p className="text-xs text-muted-foreground">{parts.join(", ")}</p>
-                        : null
-                    })()}
-                  </div>
-                  <div className="shrink-0 text-sm">
-                    {status === "pending" && <span className="text-muted-foreground">Pending</span>}
-                    {status === "creating" && <span className="text-muted-foreground animate-pulse">Creating…</span>}
-                    {status === "done" && <span className="text-green-500">Created</span>}
-                    {status === "error" && <span className="text-destructive">Failed</span>}
-                  </div>
-                </CardContent>
-                {creationErrors[i] && (
-                  <CardContent className="pt-0 pb-4">
-                    <FormError message={creationErrors[i]} />
-                  </CardContent>
-                )}
-              </Card>
-            )
-          })}
-        </div>
-
-        {!allDone && (
-          <div className="flex gap-3">
-            <Button
-              onClick={handleCreate}
-              disabled={creating}
-            >
-              {creating ? "Creating…" : `Create ${totalApps} app${totalApps !== 1 ? "s" : ""}`}
-            </Button>
-            <Button variant="outline" onClick={() => setStep(totalApps - 1)} disabled={creating}>
-              Back
-            </Button>
-          </div>
-        )}
-      </div>
-    )
-  }
-
-  // ── Step: Per-app review ──────────────────────────────────────────────────────
-
-  const form = appForms[step]
   const slugMap = currentSlugMap()
-  const isLastApp = step === totalApps - 1
+  const allDone = creationStatuses.every((s) => s === "done")
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-1">
-        <h1 className="text-xl font-semibold">App {step + 1} of {totalApps}</h1>
-      </div>
+      <h1 className="text-xl font-semibold mb-1">Configure apps</h1>
       {template && (
         <p className="text-sm text-muted-foreground mb-6">
           {template.name}{template.description ? ` — ${template.description}` : ""}
+          {" · "}{appForms.length} app{appForms.length !== 1 ? "s" : ""}
         </p>
       )}
 
-      <Card className="max-w-2xl">
-        <CardContent className="flex flex-col gap-5 pt-6">
-
-          {/* Name */}
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="appName">Name</Label>
-            <Input
-              id="appName"
-              value={form.name}
-              onChange={(e) => handleNameChange(step, e.target.value)}
-              autoFocus
-            />
-          </div>
-
-          {/* Slug */}
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="appSlug">
-              Slug
-              <span className="ml-2 text-xs text-muted-foreground font-normal">(container name)</span>
-            </Label>
-            <Input
-              id="appSlug"
-              value={form.slug}
-              onChange={(e) => handleSlugChange(step, e.target.value)}
-              className={cn(
-                form.slugState === "taken" || form.slugState === "invalid" ? "border-destructive" : "",
-                form.slugState === "available" ? "border-green-500" : "",
-              )}
-            />
-            <p className="text-xs min-h-[1rem]">{slugHint(form.slugState)}</p>
-          </div>
-
-          {/* Source type */}
-          <div className="flex flex-col gap-1.5">
-            <Label>Source</Label>
-            <div className="flex rounded-md border border-border overflow-hidden w-fit">
-              <button
-                type="button"
-                onClick={() => updateApp(step, { sourceType: "git" })}
-                className={cn(
-                  "px-4 py-1.5 text-sm transition-colors",
-                  form.sourceType === "git"
-                    ? "bg-foreground text-background font-medium"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
-                )}
-              >
-                Git
-              </button>
-              <button
-                type="button"
-                onClick={() => updateApp(step, { sourceType: "image" })}
-                className={cn(
-                  "px-4 py-1.5 text-sm transition-colors border-l border-border",
-                  form.sourceType === "image"
-                    ? "bg-foreground text-background font-medium"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
-                )}
-              >
-                Docker Image
-              </button>
-            </div>
-          </div>
-
-          {/* Git fields */}
-          {form.sourceType === "git" ? (
-            <>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="gitUrl">Git URL</Label>
-                <Input
-                  id="gitUrl"
-                  placeholder="https://github.com/org/repo"
-                  value={form.gitUrl}
-                  onChange={(e) => updateApp(step, { gitUrl: e.target.value })}
-                />
-              </div>
-
-              <CredentialSelect
-                credentials={credentials}
-                value={form.gitCredentialId}
-                onChange={(v) => updateApp(step, { gitCredentialId: v })}
-                teamId={project?.teamId}
-                gitUrl={form.gitUrl}
-              />
-
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="gitBranch">Branch</Label>
-                  <Input
-                    id="gitBranch"
-                    placeholder="main"
-                    value={form.gitBranch}
-                    onChange={(e) => updateApp(step, { gitBranch: e.target.value })}
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="appPath">
-                    App path
-                    <span className="ml-2 text-xs text-muted-foreground font-normal">optional</span>
-                  </Label>
-                  <Input
-                    id="appPath"
-                    placeholder="/"
-                    value={form.appPath}
-                    onChange={(e) => updateApp(step, { appPath: e.target.value })}
-                  />
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="imageUrl">Image</Label>
-                <Input
-                  id="imageUrl"
-                  placeholder="nginx"
-                  value={form.imageUrl}
-                  onChange={(e) => updateApp(step, { imageUrl: e.target.value })}
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="imageTag">Tag</Label>
-                <Input
-                  id="imageTag"
-                  placeholder="latest"
-                  value={form.imageTag}
-                  onChange={(e) => updateApp(step, { imageTag: e.target.value })}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Port */}
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="port">Port</Label>
-            <Input
-              id="port"
-              type="number"
-              min={1}
-              max={65535}
-              value={form.port}
-              onChange={(e) => updateApp(step, { port: e.target.value })}
-              className="w-32"
-            />
-          </div>
-
-          {/* Env vars */}
-          <div className="flex flex-col gap-2">
-            <Label>Environment variables</Label>
-            {form.envRows.length === 0 && (
-              <p className="text-xs text-muted-foreground">No env vars from template.</p>
-            )}
-            {form.envRows.map((row, ri) => {
-              const resolved = hasTemplateVars(row.value)
-                ? resolveTemplateVars(row.value, slugMap)
-                : null
-              return (
-                <div key={ri} className="flex flex-col gap-0.5">
-                  <div className="flex gap-2 items-center">
-                    <Input
-                      placeholder="KEY"
-                      value={row.key}
-                      onChange={(e) => updateEnvRow(step, ri, "key", e.target.value)}
-                      className="font-mono text-xs w-40 shrink-0"
-                    />
-                    <Input
-                      placeholder="value"
-                      value={row.value}
-                      onChange={(e) => updateEnvRow(step, ri, "value", e.target.value)}
-                      className="font-mono text-xs"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removeEnvRow(step, ri)}
-                      className="text-muted-foreground hover:text-destructive text-xs shrink-0"
-                      aria-label="Remove"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                  {resolved !== null && (
-                    <p className="text-xs text-muted-foreground pl-1">
-                      → <code>{resolved}</code>
+      <div className="flex flex-col gap-6">
+        {appForms.map((form, i) => {
+          const status = creationStatuses[i]
+          return (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">
+                      App {i + 1}{form.name ? `: ${form.name}` : ""}
                     </p>
-                  )}
-                </div>
-              )
-            })}
-            <Button type="button" variant="outline" size="sm" onClick={() => addEnvRow(step)} className="w-fit">
-              + Add variable
-            </Button>
-          </div>
 
-          {/* Required secrets */}
-          {template && (template.apps[step]?.secrets ?? []).length > 0 && (
-            <div className="flex flex-col gap-3">
-              <Label>Secrets</Label>
-              <p className="text-xs text-muted-foreground -mt-1">
-                Required by the template. Values are encrypted at rest.
-              </p>
-              {(template.apps[step]?.secrets ?? []).map((secret) => (
-                <div key={secret.name} className="flex flex-col gap-1.5">
-                  <Label htmlFor={`secret-${secret.name}`} className="font-mono text-xs">
-                    {secret.name}
-                    <span className="ml-2 text-xs font-sans text-destructive font-normal">required</span>
-                  </Label>
-                  {secret.description && (
-                    <p className="text-xs text-muted-foreground">{secret.description}</p>
-                  )}
-                  <Input
-                    id={`secret-${secret.name}`}
-                    type="password"
-                    placeholder="secret value"
-                    value={form.secretValues[secret.name] ?? ""}
-                    onChange={(e) =>
-                      updateApp(step, {
-                        secretValues: { ...form.secretValues, [secret.name]: e.target.value },
-                      })
-                    }
+                  </div>
+                  <div className="shrink-0 text-sm">
+                    {status === "creating" && (
+                      <span className="text-muted-foreground animate-pulse">Creating…</span>
+                    )}
+                    {status === "done" && <span className="text-green-500">Created</span>}
+                    {status === "error" && <span className="text-destructive">Failed</span>}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4 pt-2">
+                {project && (
+                  <AppFormFields
+                    value={form}
+                    onChange={(patch) => {
+                      // Keep name → slug in sync if slug was auto-generated from the original template slug
+                      if (patch.name !== undefined && patch.slug === undefined) {
+                        handleNameChange(i, patch.name)
+                        return
+                      }
+                      updateApp(i, patch)
+                    }}
+                    projectId={project.id}
+                    credentials={credentials}
+                    teamId={project.teamId}
+                    slugMap={slugMap}
+                    autoFocus={i === 0}
                   />
-                </div>
-              ))}
-            </div>
-          )}
+                )}
+                {creationErrors[i] && <FormError message={creationErrors[i]} />}
+              </CardContent>
+            </Card>
+          )
+        })}
 
-          {/* Advanced: canetteConfig */}
-          <Collapsible>
-            <CollapsibleTrigger className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1">
-              Advanced configuration
-            </CollapsibleTrigger>
-            <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
-              <p className="text-xs text-muted-foreground">
-                Runtime, resource, and ingress settings from the template. Applied at deploy time; repo <code>canette.yaml</code> overrides these.
-              </p>
-              <Textarea
-                value={form.canetteConfig}
-                onChange={(e) => updateApp(step, { canetteConfig: e.target.value })}
-                className="font-mono text-xs min-h-[120px]"
-                placeholder="# No extra config from template"
-              />
-            </CollapsibleContent>
-          </Collapsible>
-
-          {/* Navigation */}
-          <div className="flex gap-3 pt-2">
-            <Button onClick={() => setStep(isLastApp ? totalApps : step + 1)} disabled={!currentStepValid()}>
-              {isLastApp ? "Review" : "Next"}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => setStep(step - 1)}
-            >
-              {step === 0 ? "Back to load" : "Back"}
-            </Button>
-          </div>
-
-        </CardContent>
-      </Card>
+        {!allDone && (
+          <Card>
+            <CardContent className="flex justify-end gap-3 py-4">
+              <Button variant="ghost" onClick={() => setLoaded(false)} disabled={creating}>
+                Back
+              </Button>
+              <Button onClick={handleCreate} disabled={creating || !allAppsValid()}>
+                {creating
+                  ? "Creating…"
+                  : `Create ${appForms.length} app${appForms.length !== 1 ? "s" : ""}`}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useEffect } from "react"
 import { useParams, useRouter } from "next/navigation"
+import { ClipboardPaste } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardHeader, CardDescription } from "@/components/ui/card"
 import { FormError } from "@/components/ui/form-error"
 import { AppFormFields, toSlug, isValidEnvKey } from "@/components/app-form-fields"
 import type { AppFormValue } from "@/components/app-form-fields"
-import { cn } from "@/lib/utils"
 import * as api from "@/lib/api"
 import { resolveTemplateVars, buildSlugMap } from "@/lib/template"
 import type { AppTemplate, GitCredential, Project } from "@canette/types"
@@ -59,9 +58,7 @@ export default function FromTemplatePage() {
   const [appForms, setAppForms] = useState<AppFormValue[]>([])
 
   // Load form state
-  const [loadInput, setLoadInput] = useState("paste")
   const [yamlText, setYamlText] = useState("")
-  const [urlText, setUrlText] = useState("")
   const [loadError, setLoadError] = useState("")
   const [loading, setLoading] = useState(false)
 
@@ -89,16 +86,25 @@ export default function FromTemplatePage() {
 
   // ── Load template ────────────────────────────────────────────────────────────
 
+  async function handlePasteFromClipboard() {
+    try {
+      const text = await navigator.clipboard.readText()
+      setYamlText(text)
+      setLoadError("")
+    } catch {
+      // Clipboard access denied — user can paste manually
+    }
+  }
+
   async function handleLoad() {
     setLoadError("")
+    if (!yamlText.trim()) {
+      setLoadError("Paste a template first")
+      return
+    }
     setLoading(true)
     try {
-      const body = loadInput === "url" ? { url: urlText.trim() } : { yaml: yamlText.trim() }
-      if (!body.yaml && !body.url) {
-        setLoadError(loadInput === "url" ? "Enter a URL" : "Paste a template first")
-        return
-      }
-      const parsed = await api.templates.parse(body)
+      const parsed = await api.templates.parse({ yaml: yamlText.trim() })
       setTemplate(parsed)
       setOriginalSlugs(parsed.apps.map((a) => a.slug))
       setAppForms(parsed.apps.map(formValueFromTemplate))
@@ -212,55 +218,24 @@ export default function FromTemplatePage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-5">
-            <div className="flex flex-col gap-4">
-              <div className="flex rounded-md border border-border overflow-hidden w-fit">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <Label>Template YAML</Label>
                 <button
                   type="button"
-                  onClick={() => setLoadInput("paste")}
-                  className={cn(
-                    "px-4 py-1.5 text-sm transition-colors",
-                    loadInput === "paste"
-                      ? "bg-foreground text-background font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted",
-                  )}
+                  onClick={handlePasteFromClipboard}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  Paste YAML
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setLoadInput("url")}
-                  className={cn(
-                    "px-4 py-1.5 text-sm transition-colors border-l border-border",
-                    loadInput === "url"
-                      ? "bg-foreground text-background font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted",
-                  )}
-                >
-                  From URL
+                  <ClipboardPaste className="size-3.5" />
+                  Paste from clipboard
                 </button>
               </div>
-
-              {loadInput === "paste" ? (
-                <Textarea
-                  placeholder={`name: "Full-stack starter"\napps:\n  - name: API\n    slug: api\n    source_type: git\n    git_url: https://github.com/org/repo\n    port: 3000`}
-                  value={yamlText}
-                  onChange={(e) => setYamlText(e.target.value)}
-                  className="font-mono text-xs min-h-[200px]"
-                />
-              ) : (
-                <div className="flex flex-col gap-1.5">
-                  <Label htmlFor="templateUrl">Template URL</Label>
-                  <Input
-                    id="templateUrl"
-                    placeholder="https://raw.githubusercontent.com/org/repo/main/canette-template.yaml"
-                    value={urlText}
-                    onChange={(e) => setUrlText(e.target.value)}
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Must be a public URL. The file is fetched server-side.
-                  </p>
-                </div>
-              )}
+              <Textarea
+                placeholder={`name: "Full-stack starter"\napps:\n  - name: API\n    slug: api\n    source_type: git\n    git_url: https://github.com/org/repo\n    port: 3000`}
+                value={yamlText}
+                onChange={(e) => setYamlText(e.target.value)}
+                className="font-mono text-xs min-h-[280px]"
+              />
             </div>
 
             {loadError && <FormError message={loadError} />}

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/from-template/page.tsx
@@ -1,0 +1,744 @@
+"use client"
+
+import { useState, useEffect, useRef, useCallback } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Card, CardContent, CardHeader, CardDescription } from "@/components/ui/card"
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible"
+import { FormError } from "@/components/ui/form-error"
+import { CredentialSelect } from "@/components/credential-select"
+import { cn } from "@/lib/utils"
+import * as api from "@/lib/api"
+import { resolveTemplateVars, hasTemplateVars, buildSlugMap } from "@/lib/template"
+import type { AppTemplate, GitCredential, Project } from "@canette/types"
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type SlugState = "idle" | "checking" | "available" | "taken" | "invalid"
+
+type AppFormState = {
+  originalSlug: string
+  name: string
+  slug: string
+  slugState: SlugState
+  sourceType: "git" | "image"
+  gitUrl: string
+  gitBranch: string
+  appPath: string
+  imageUrl: string
+  imageTag: string
+  port: string
+  gitCredentialId: string
+  envRows: Array<{ key: string; value: string }>
+  secretValues: Record<string, string>
+  canetteConfig: string
+}
+
+type CreationStatus = "pending" | "creating" | "done" | "error"
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 63)
+}
+
+function formStateFromTemplate(app: AppTemplate["apps"][number]): AppFormState {
+  return {
+    originalSlug: app.slug,
+    name: app.name,
+    slug: app.slug,
+    slugState: "idle",
+    sourceType: app.sourceType,
+    gitUrl: app.gitUrl ?? "",
+    gitBranch: app.gitBranch ?? "main",
+    appPath: app.appPath ?? "",
+    imageUrl: app.imageUrl ?? "",
+    imageTag: app.imageTag ?? "latest",
+    port: app.port?.toString() ?? "3000",
+    gitCredentialId: app.gitCredentialId ?? "",
+    envRows: app.env
+      ? Object.entries(app.env).map(([key, value]) => ({ key, value }))
+      : [],
+    secretValues: Object.fromEntries((app.secrets ?? []).map((s) => [s.name, ""])),
+    canetteConfig: app.canetteConfig ?? "",
+  }
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export default function FromTemplatePage() {
+  const { slug: projectSlug } = useParams<{ slug: string }>()
+  const router = useRouter()
+
+  const [project, setProject] = useState<Project | null>(null)
+  const [credentials, setCredentials] = useState<GitCredential[]>([])
+
+  // step: -1 = load, 0..N-1 = per-app, N = summary
+  const [step, setStep] = useState(-1)
+  const [template, setTemplate] = useState<AppTemplate | null>(null)
+  const [appForms, setAppForms] = useState<AppFormState[]>([])
+
+  const [loadInput, setLoadInput] = useState("paste")
+  const [yamlText, setYamlText] = useState("")
+  const [urlText, setUrlText] = useState("")
+  const [loadError, setLoadError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const [creationStatuses, setCreationStatuses] = useState<CreationStatus[]>([])
+  const [creationErrors, setCreationErrors] = useState<string[]>([])
+  const [creating, setCreating] = useState(false)
+
+  const slugTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    api.projects.get(projectSlug)
+      .then(setProject)
+      .catch(() => {})
+    api.projects.listCredentials(projectSlug).then(setCredentials).catch(() => {})
+  }, [projectSlug])
+
+  // ── Slug live-check for the active app step ─────────────────────────────────
+
+  const runSlugCheck = useCallback(
+    (appIndex: number, slug: string) => {
+      if (!project) return
+      if (slugTimerRef.current) clearTimeout(slugTimerRef.current)
+
+      if (!slug) {
+        updateApp(appIndex, { slugState: "idle" })
+        return
+      }
+      const valid = /^[a-z0-9][a-z0-9-]{0,62}$/.test(slug) && !slug.endsWith("-")
+      if (!valid) {
+        updateApp(appIndex, { slugState: "invalid" })
+        return
+      }
+
+      updateApp(appIndex, { slugState: "checking" })
+      slugTimerRef.current = setTimeout(async () => {
+        try {
+          const res = await fetch(
+            `/api/v1/projects/${project.id}/apps/slug-available?slug=${encodeURIComponent(slug)}`,
+            { credentials: "include" },
+          )
+          const data = await res.json()
+          updateApp(appIndex, { slugState: data.available ? "available" : "taken" })
+        } catch {
+          updateApp(appIndex, { slugState: "idle" })
+        }
+      }, 400)
+    },
+    [project],
+  )
+
+  // Re-run check when project loads for the active step
+  useEffect(() => {
+    if (step >= 0 && step < appForms.length && project) {
+      runSlugCheck(step, appForms[step].slug)
+    }
+  }, [step, project]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── State helpers ───────────────────────────────────────────────────────────
+
+  function updateApp(index: number, patch: Partial<AppFormState>) {
+    setAppForms((prev) => prev.map((f, i) => (i === index ? { ...f, ...patch } : f)))
+  }
+
+  // ── Load template ───────────────────────────────────────────────────────────
+
+  async function handleLoad() {
+    setLoadError("")
+    setLoading(true)
+    try {
+      const body = loadInput === "url" ? { url: urlText.trim() } : { yaml: yamlText.trim() }
+      if (!body.yaml && !body.url) {
+        setLoadError(loadInput === "url" ? "Enter a URL" : "Paste a template first")
+        return
+      }
+      const parsed = await api.templates.parse(body)
+      setTemplate(parsed)
+      setAppForms(parsed.apps.map(formStateFromTemplate))
+      setCreationStatuses(parsed.apps.map(() => "pending"))
+      setCreationErrors(parsed.apps.map(() => ""))
+      setStep(0)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load template")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // ── Per-app field handlers ───────────────────────────────────────────────────
+
+  function handleSlugChange(index: number, value: string) {
+    updateApp(index, { slug: value })
+    runSlugCheck(index, value)
+  }
+
+  function handleNameChange(index: number, value: string) {
+    const form = appForms[index]
+    const auto = toSlug(form.name) === form.slug
+    updateApp(index, { name: value, ...(auto ? { slug: toSlug(value) } : {}) })
+    if (auto) runSlugCheck(index, toSlug(value))
+  }
+
+  // ── Env row helpers ──────────────────────────────────────────────────────────
+
+  function addEnvRow(index: number) {
+    updateApp(index, {
+      envRows: [...appForms[index].envRows, { key: "", value: "" }],
+    })
+  }
+
+  function updateEnvRow(
+    appIndex: number,
+    rowIndex: number,
+    field: "key" | "value",
+    value: string,
+  ) {
+    const rows = appForms[appIndex].envRows.map((r, i) =>
+      i === rowIndex ? { ...r, [field]: value } : r,
+    )
+    updateApp(appIndex, { envRows: rows })
+  }
+
+  function removeEnvRow(appIndex: number, rowIndex: number) {
+    updateApp(appIndex, {
+      envRows: appForms[appIndex].envRows.filter((_, i) => i !== rowIndex),
+    })
+  }
+
+  // ── Current slug map (for template var preview) ──────────────────────────────
+
+  function currentSlugMap(): Record<string, string> {
+    return buildSlugMap(
+      appForms.map((f) => ({ originalSlug: f.originalSlug, chosenSlug: f.slug })),
+    )
+  }
+
+  // ── Validation for the current step ─────────────────────────────────────────
+
+  function currentStepValid(): boolean {
+    if (step < 0 || step >= appForms.length) return true
+    const form = appForms[step]
+    if (!form.name.trim()) return false
+    if (form.slugState !== "available") return false
+    if (form.sourceType === "git" && !form.gitUrl.trim()) return false
+    if (form.sourceType === "image" && !form.imageUrl.trim()) return false
+    const port = parseInt(form.port, 10)
+    if (isNaN(port) || port < 1 || port > 65535) return false
+    const missingSecrets = Object.entries(form.secretValues).filter(([, v]) => !v)
+    if (missingSecrets.length > 0) return false
+    return true
+  }
+
+  // ── Create all apps ──────────────────────────────────────────────────────────
+
+  async function handleCreate() {
+    if (!project) return
+    setCreating(true)
+
+    const slugMap = buildSlugMap(
+      appForms.map((f) => ({ originalSlug: f.originalSlug, chosenSlug: f.slug })),
+    )
+
+    for (let i = 0; i < appForms.length; i++) {
+      const form = appForms[i]
+      setCreationStatuses((prev) => prev.map((s, idx) => (idx === i ? "creating" : s)))
+
+      try {
+        const port = parseInt(form.port, 10)
+        const appBody =
+          form.sourceType === "git"
+            ? {
+                name: form.name.trim(),
+                slug: form.slug,
+                sourceType: "git" as const,
+                gitUrl: form.gitUrl.trim(),
+                gitBranch: form.gitBranch.trim() || "main",
+                appPath: form.appPath.trim() || undefined,
+                gitCredentialId: form.gitCredentialId || undefined,
+                port,
+                canetteConfig: form.canetteConfig.trim() || undefined,
+              }
+            : {
+                name: form.name.trim(),
+                slug: form.slug,
+                sourceType: "image" as const,
+                imageUrl: form.imageUrl.trim(),
+                imageTag: form.imageTag.trim() || "latest",
+                port,
+                canetteConfig: form.canetteConfig.trim() || undefined,
+              }
+
+        const created = await api.apps.create(project.id, appBody)
+
+        // Set env vars (resolve cross-app references)
+        for (const { key, value } of form.envRows) {
+          if (!key.trim()) continue
+          const resolved = resolveTemplateVars(value, slugMap)
+          await api.env.putVar(created.id, key.trim(), resolved)
+        }
+
+        // Set secrets
+        for (const [key, value] of Object.entries(form.secretValues)) {
+          if (value) await api.env.putSecret(created.id, key, value)
+        }
+
+        setCreationStatuses((prev) => prev.map((s, idx) => (idx === i ? "done" : s)))
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Failed to create app"
+        setCreationStatuses((prev) => prev.map((s, idx) => (idx === i ? "error" : s)))
+        setCreationErrors((prev) => prev.map((s, idx) => (idx === i ? msg : s)))
+        setCreating(false)
+        return
+      }
+    }
+
+    setCreating(false)
+    router.push(`/dashboard/projects/${projectSlug}`)
+  }
+
+  // ── Render helpers ────────────────────────────────────────────────────────────
+
+  function slugHint(state: SlugState) {
+    return {
+      idle: null,
+      checking: <span className="text-muted-foreground">Checking…</span>,
+      available: <span className="text-green-500">Available</span>,
+      taken: <span className="text-destructive">Already taken in this project</span>,
+      invalid: <span className="text-destructive">Lowercase letters, numbers and hyphens only</span>,
+    }[state]
+  }
+
+  const totalApps = appForms.length
+
+  // ── Step: Load ───────────────────────────────────────────────────────────────
+
+  if (step === -1) {
+    return (
+      <div>
+        <h1 className="text-xl font-semibold mb-6">From template</h1>
+        <Card className="max-w-2xl">
+          <CardHeader>
+            <CardDescription>
+              Load a <code className="text-xs">canette-template.yaml</code> file to create one or more apps at once.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-5">
+            <div className="flex flex-col gap-4">
+              <div className="flex rounded-md border border-border overflow-hidden w-fit">
+                <button
+                  type="button"
+                  onClick={() => setLoadInput("paste")}
+                  className={cn(
+                    "px-4 py-1.5 text-sm transition-colors",
+                    loadInput === "paste"
+                      ? "bg-foreground text-background font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                  )}
+                >
+                  Paste YAML
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLoadInput("url")}
+                  className={cn(
+                    "px-4 py-1.5 text-sm transition-colors border-l border-border",
+                    loadInput === "url"
+                      ? "bg-foreground text-background font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                  )}
+                >
+                  From URL
+                </button>
+              </div>
+
+              {loadInput === "paste" ? (
+                <Textarea
+                  placeholder={`name: "Full-stack starter"\napps:\n  - name: API\n    slug: api\n    source_type: git\n    git_url: https://github.com/org/repo\n    port: 3000`}
+                  value={yamlText}
+                  onChange={(e) => setYamlText(e.target.value)}
+                  className="font-mono text-xs min-h-[200px]"
+                />
+              ) : (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="templateUrl">Template URL</Label>
+                  <Input
+                    id="templateUrl"
+                    placeholder="https://raw.githubusercontent.com/org/repo/main/canette-template.yaml"
+                    value={urlText}
+                    onChange={(e) => setUrlText(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Must be a public URL. The file is fetched server-side.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {loadError && <FormError message={loadError} />}
+
+            <div className="flex gap-3">
+              <Button onClick={handleLoad} disabled={loading}>
+                {loading ? "Loading…" : "Load template"}
+              </Button>
+              <Button variant="ghost" asChild>
+                <a href={`/dashboard/projects/${projectSlug}`}>Cancel</a>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  // ── Step: Summary / Create ────────────────────────────────────────────────────
+
+  if (step === totalApps) {
+    const allDone = creationStatuses.every((s) => s === "done")
+
+    return (
+      <div>
+        <h1 className="text-xl font-semibold mb-2">Review and create</h1>
+        <p className="text-sm text-muted-foreground mb-6">
+          {template?.name} — {totalApps} app{totalApps !== 1 ? "s" : ""} will be added to this project.
+        </p>
+
+        <div className="flex flex-col gap-3 max-w-2xl mb-6">
+          {appForms.map((form, i) => {
+            const status = creationStatuses[i]
+            return (
+              <Card key={i}>
+                <CardContent className="flex items-center justify-between gap-3 py-4">
+                  <div className="flex flex-col gap-0.5 min-w-0">
+                    <p className="text-sm font-medium truncate">{form.name}</p>
+                    <p className="text-xs text-muted-foreground font-mono">{form.slug}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {form.sourceType === "git" ? form.gitUrl || "—" : `${form.imageUrl}:${form.imageTag}`}
+                    </p>
+                    {(() => {
+                      const envCount = form.envRows.filter(r => r.key).length
+                      const secretCount = Object.keys(form.secretValues).length
+                      const parts = []
+                      if (envCount > 0) parts.push(`${envCount} env var${envCount !== 1 ? "s" : ""}`)
+                      if (secretCount > 0) parts.push(`${secretCount} secret${secretCount !== 1 ? "s" : ""}`)
+                      return parts.length > 0
+                        ? <p className="text-xs text-muted-foreground">{parts.join(", ")}</p>
+                        : null
+                    })()}
+                  </div>
+                  <div className="shrink-0 text-sm">
+                    {status === "pending" && <span className="text-muted-foreground">Pending</span>}
+                    {status === "creating" && <span className="text-muted-foreground animate-pulse">Creating…</span>}
+                    {status === "done" && <span className="text-green-500">Created</span>}
+                    {status === "error" && <span className="text-destructive">Failed</span>}
+                  </div>
+                </CardContent>
+                {creationErrors[i] && (
+                  <CardContent className="pt-0 pb-4">
+                    <FormError message={creationErrors[i]} />
+                  </CardContent>
+                )}
+              </Card>
+            )
+          })}
+        </div>
+
+        {!allDone && (
+          <div className="flex gap-3">
+            <Button
+              onClick={handleCreate}
+              disabled={creating}
+            >
+              {creating ? "Creating…" : `Create ${totalApps} app${totalApps !== 1 ? "s" : ""}`}
+            </Button>
+            <Button variant="outline" onClick={() => setStep(totalApps - 1)} disabled={creating}>
+              Back
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // ── Step: Per-app review ──────────────────────────────────────────────────────
+
+  const form = appForms[step]
+  const slugMap = currentSlugMap()
+  const isLastApp = step === totalApps - 1
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <h1 className="text-xl font-semibold">App {step + 1} of {totalApps}</h1>
+      </div>
+      {template && (
+        <p className="text-sm text-muted-foreground mb-6">
+          {template.name}{template.description ? ` — ${template.description}` : ""}
+        </p>
+      )}
+
+      <Card className="max-w-2xl">
+        <CardContent className="flex flex-col gap-5 pt-6">
+
+          {/* Name */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="appName">Name</Label>
+            <Input
+              id="appName"
+              value={form.name}
+              onChange={(e) => handleNameChange(step, e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          {/* Slug */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="appSlug">
+              Slug
+              <span className="ml-2 text-xs text-muted-foreground font-normal">(container name)</span>
+            </Label>
+            <Input
+              id="appSlug"
+              value={form.slug}
+              onChange={(e) => handleSlugChange(step, e.target.value)}
+              className={cn(
+                form.slugState === "taken" || form.slugState === "invalid" ? "border-destructive" : "",
+                form.slugState === "available" ? "border-green-500" : "",
+              )}
+            />
+            <p className="text-xs min-h-[1rem]">{slugHint(form.slugState)}</p>
+          </div>
+
+          {/* Source type */}
+          <div className="flex flex-col gap-1.5">
+            <Label>Source</Label>
+            <div className="flex rounded-md border border-border overflow-hidden w-fit">
+              <button
+                type="button"
+                onClick={() => updateApp(step, { sourceType: "git" })}
+                className={cn(
+                  "px-4 py-1.5 text-sm transition-colors",
+                  form.sourceType === "git"
+                    ? "bg-foreground text-background font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                )}
+              >
+                Git
+              </button>
+              <button
+                type="button"
+                onClick={() => updateApp(step, { sourceType: "image" })}
+                className={cn(
+                  "px-4 py-1.5 text-sm transition-colors border-l border-border",
+                  form.sourceType === "image"
+                    ? "bg-foreground text-background font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted",
+                )}
+              >
+                Docker Image
+              </button>
+            </div>
+          </div>
+
+          {/* Git fields */}
+          {form.sourceType === "git" ? (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="gitUrl">Git URL</Label>
+                <Input
+                  id="gitUrl"
+                  placeholder="https://github.com/org/repo"
+                  value={form.gitUrl}
+                  onChange={(e) => updateApp(step, { gitUrl: e.target.value })}
+                />
+              </div>
+
+              <CredentialSelect
+                credentials={credentials}
+                value={form.gitCredentialId}
+                onChange={(v) => updateApp(step, { gitCredentialId: v })}
+                teamId={project?.teamId}
+                gitUrl={form.gitUrl}
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="gitBranch">Branch</Label>
+                  <Input
+                    id="gitBranch"
+                    placeholder="main"
+                    value={form.gitBranch}
+                    onChange={(e) => updateApp(step, { gitBranch: e.target.value })}
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="appPath">
+                    App path
+                    <span className="ml-2 text-xs text-muted-foreground font-normal">optional</span>
+                  </Label>
+                  <Input
+                    id="appPath"
+                    placeholder="/"
+                    value={form.appPath}
+                    onChange={(e) => updateApp(step, { appPath: e.target.value })}
+                  />
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="imageUrl">Image</Label>
+                <Input
+                  id="imageUrl"
+                  placeholder="nginx"
+                  value={form.imageUrl}
+                  onChange={(e) => updateApp(step, { imageUrl: e.target.value })}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="imageTag">Tag</Label>
+                <Input
+                  id="imageTag"
+                  placeholder="latest"
+                  value={form.imageTag}
+                  onChange={(e) => updateApp(step, { imageTag: e.target.value })}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Port */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="port">Port</Label>
+            <Input
+              id="port"
+              type="number"
+              min={1}
+              max={65535}
+              value={form.port}
+              onChange={(e) => updateApp(step, { port: e.target.value })}
+              className="w-32"
+            />
+          </div>
+
+          {/* Env vars */}
+          <div className="flex flex-col gap-2">
+            <Label>Environment variables</Label>
+            {form.envRows.length === 0 && (
+              <p className="text-xs text-muted-foreground">No env vars from template.</p>
+            )}
+            {form.envRows.map((row, ri) => {
+              const resolved = hasTemplateVars(row.value)
+                ? resolveTemplateVars(row.value, slugMap)
+                : null
+              return (
+                <div key={ri} className="flex flex-col gap-0.5">
+                  <div className="flex gap-2 items-center">
+                    <Input
+                      placeholder="KEY"
+                      value={row.key}
+                      onChange={(e) => updateEnvRow(step, ri, "key", e.target.value)}
+                      className="font-mono text-xs w-40 shrink-0"
+                    />
+                    <Input
+                      placeholder="value"
+                      value={row.value}
+                      onChange={(e) => updateEnvRow(step, ri, "value", e.target.value)}
+                      className="font-mono text-xs"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeEnvRow(step, ri)}
+                      className="text-muted-foreground hover:text-destructive text-xs shrink-0"
+                      aria-label="Remove"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                  {resolved !== null && (
+                    <p className="text-xs text-muted-foreground pl-1">
+                      → <code>{resolved}</code>
+                    </p>
+                  )}
+                </div>
+              )
+            })}
+            <Button type="button" variant="outline" size="sm" onClick={() => addEnvRow(step)} className="w-fit">
+              + Add variable
+            </Button>
+          </div>
+
+          {/* Required secrets */}
+          {template && (template.apps[step]?.secrets ?? []).length > 0 && (
+            <div className="flex flex-col gap-3">
+              <Label>Secrets</Label>
+              <p className="text-xs text-muted-foreground -mt-1">
+                Required by the template. Values are encrypted at rest.
+              </p>
+              {(template.apps[step]?.secrets ?? []).map((secret) => (
+                <div key={secret.name} className="flex flex-col gap-1.5">
+                  <Label htmlFor={`secret-${secret.name}`} className="font-mono text-xs">
+                    {secret.name}
+                    <span className="ml-2 text-xs font-sans text-destructive font-normal">required</span>
+                  </Label>
+                  {secret.description && (
+                    <p className="text-xs text-muted-foreground">{secret.description}</p>
+                  )}
+                  <Input
+                    id={`secret-${secret.name}`}
+                    type="password"
+                    placeholder="secret value"
+                    value={form.secretValues[secret.name] ?? ""}
+                    onChange={(e) =>
+                      updateApp(step, {
+                        secretValues: { ...form.secretValues, [secret.name]: e.target.value },
+                      })
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Advanced: canetteConfig */}
+          <Collapsible>
+            <CollapsibleTrigger className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1">
+              Advanced configuration
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
+              <p className="text-xs text-muted-foreground">
+                Runtime, resource, and ingress settings from the template. Applied at deploy time; repo <code>canette.yaml</code> overrides these.
+              </p>
+              <Textarea
+                value={form.canetteConfig}
+                onChange={(e) => updateApp(step, { canetteConfig: e.target.value })}
+                className="font-mono text-xs min-h-[120px]"
+                placeholder="# No extra config from template"
+              />
+            </CollapsibleContent>
+          </Collapsible>
+
+          {/* Navigation */}
+          <div className="flex gap-3 pt-2">
+            <Button onClick={() => setStep(isLastApp ? totalApps : step + 1)} disabled={!currentStepValid()}>
+              {isLastApp ? "Review" : "Next"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setStep(step - 1)}
+            >
+              {step === 0 ? "Back to load" : "Back"}
+            </Button>
+          </div>
+
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/layout.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/layout.tsx
@@ -12,6 +12,7 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
   const [project, setProject] = useState<Project | null>(null)
 
   const isAppPage = pathname.includes(`/projects/${slug}/apps/`)
+  const isFullPage = isAppPage || pathname.includes(`/projects/${slug}/from-template`)
 
   const load = useCallback(async () => {
     try {
@@ -21,10 +22,10 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
   }, [slug])
 
   useEffect(() => {
-    if (!isAppPage) load()
-  }, [isAppPage, load])
+    if (!isFullPage) load()
+  }, [isFullPage, load])
 
-  if (isAppPage) return <>{children}</>
+  if (isFullPage) return <>{children}</>
 
   const base = `/dashboard/projects/${slug}`
   const isSettings = pathname.startsWith(`${base}/settings`)

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
@@ -50,16 +50,6 @@ export default function ProjectPage() {
         <p className="text-sm text-muted-foreground mb-6">{project.description}</p>
       )}
 
-      {!loading && (
-        <div className="flex gap-2 mb-6">
-          <Button size="sm" asChild>
-            <Link href={`/dashboard/projects/${slug}/apps/new`}>New app</Link>
-          </Button>
-          <Button size="sm" variant="outline" asChild>
-            <Link href={`/dashboard/projects/${slug}/from-template`}>From template</Link>
-          </Button>
-        </div>
-      )}
 
       {loading ? (
         <SkeletonText />

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useParams } from "next/navigation"
 import { SkeletonText } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import type { App, Project } from "@canette/types"
 
@@ -49,6 +50,17 @@ export default function ProjectPage() {
         <p className="text-sm text-muted-foreground mb-6">{project.description}</p>
       )}
 
+      {!loading && (
+        <div className="flex gap-2 mb-6">
+          <Button size="sm" asChild>
+            <Link href={`/dashboard/projects/${slug}/apps/new`}>New app</Link>
+          </Button>
+          <Button size="sm" variant="outline" asChild>
+            <Link href={`/dashboard/projects/${slug}/from-template`}>From template</Link>
+          </Button>
+        </div>
+      )}
+
       {loading ? (
         <SkeletonText />
       ) : apps.length === 0 ? (
@@ -56,12 +68,16 @@ export default function ProjectPage() {
           <p className="text-sm text-muted-foreground max-w-sm">
             An app is a deployable service — built from a Git repository or Docker image and served at its own URL.
           </p>
-          <Link
-            href={`/dashboard/projects/${slug}/apps/new`}
-            className="text-sm font-medium underline underline-offset-2 hover:no-underline"
-          >
-            Add the first app
-          </Link>
+          <p className="text-xs text-muted-foreground">
+            Create one manually or{" "}
+            <Link
+              href={`/dashboard/projects/${slug}/from-template`}
+              className="underline underline-offset-2 hover:no-underline"
+            >
+              load a template
+            </Link>
+            {" "}to set up a full stack at once.
+          </p>
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
@@ -58,7 +58,13 @@ export default function ProjectPage() {
             An app is a deployable service — built from a Git repository or Docker image and served at its own URL.
           </p>
           <p className="text-xs text-muted-foreground">
-            Create one manually or{" "}
+            <Link
+              href={`/dashboard/projects/${slug}/apps/new`}
+              className="underline underline-offset-2 hover:no-underline"
+            >
+              Create one manually
+            </Link>
+            {" "}or{" "}
             <Link
               href={`/dashboard/projects/${slug}/from-template`}
               className="underline underline-offset-2 hover:no-underline"

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/[slug]/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link"
 import { useParams } from "next/navigation"
 import { SkeletonText } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import type { App, Project } from "@canette/types"
 

--- a/apps/ui/src/app/(authenticated)/dashboard/projects/new/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/projects/new/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/
 import { cn } from "@/lib/utils"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
+import { useSelectedTeam } from "@/lib/team-context"
 import * as api from "@/lib/api"
 import type { Team } from "@canette/types"
 
@@ -33,16 +34,18 @@ export default function NewProjectPage() {
   const [submitting, setSubmitting] = useState(false)
   const checkTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const { selectedTeamId } = useSelectedTeam()
   const [teams, setTeams] = useState<Team[]>([])
   const [teamId, setTeamId] = useState<string>("")
 
-  // Load user's teams
+  // Load user's teams, pre-selecting the sidebar's active team
   useEffect(() => {
     api.teams.list().then((data) => {
       setTeams(data)
-      if (data.length > 0) setTeamId(data[0].id)
+      const match = data.find((t) => t.id === selectedTeamId)
+      setTeamId(match?.id ?? data[0]?.id ?? "")
     }).catch(() => {})
-  }, [])
+  }, [selectedTeamId])
 
   // Auto-derive slug from name unless user has manually edited it
   useEffect(() => {

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/page.tsx
@@ -5,11 +5,13 @@ import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { SkeletonText } from "@/components/ui/skeleton"
+import { useSelectedTeam } from "@/lib/team-context"
 import * as api from "@/lib/api"
 import type { Team } from "@canette/types"
 
 export default function TeamsPage() {
   const router = useRouter()
+  const { setSelectedTeamId } = useSelectedTeam()
   const [teams, setTeams] = useState<Team[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -28,7 +30,7 @@ export default function TeamsPage() {
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {teams.map((team) => (
             <Card key={team.id} className="cursor-pointer hover:border-foreground/20 transition-colors"
-              onClick={() => router.push(`/dashboard/teams/${team.id}`)}>
+              onClick={() => { setSelectedTeamId(team.id); router.push(`/dashboard/teams/${team.id}`) }}>
               <CardHeader className="pb-2">
                 <CardTitle className="text-base flex items-center gap-2">
                   {team.name}

--- a/apps/ui/src/app/(authenticated)/dashboard/teams/page.tsx
+++ b/apps/ui/src/app/(authenticated)/dashboard/teams/page.tsx
@@ -2,19 +2,14 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { useSession } from "@/lib/auth-client"
 import { SkeletonText } from "@/components/ui/skeleton"
 import * as api from "@/lib/api"
 import type { Team } from "@canette/types"
 
 export default function TeamsPage() {
   const router = useRouter()
-  const { data: session } = useSession()
-  const isAdmin = session?.user?.role === "admin"
-
   const [teams, setTeams] = useState<Team[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -24,12 +19,7 @@ export default function TeamsPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Teams</h1>
-        {isAdmin && (
-          <Button size="sm" onClick={() => router.push("/admin/teams/new")}>New team</Button>
-        )}
-      </div>
+      <h1 className="text-xl font-semibold">Teams</h1>
       {loading ? (
         <SkeletonText />
       ) : teams.length === 0 ? (

--- a/apps/ui/src/components/app-form-fields.tsx
+++ b/apps/ui/src/components/app-form-fields.tsx
@@ -251,14 +251,6 @@ export function AppFormFields({
             )}
           </div>
 
-          <CredentialSelect
-            credentials={credentials}
-            value={value.gitCredentialId}
-            onChange={(v) => onChange({ gitCredentialId: v })}
-            teamId={teamId}
-            gitUrl={value.gitUrl}
-          />
-
           <div className="grid grid-cols-2 gap-4">
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="gitBranch">Branch</Label>
@@ -282,6 +274,14 @@ export function AppFormFields({
               />
             </div>
           </div>
+
+          <CredentialSelect
+            credentials={credentials}
+            value={value.gitCredentialId}
+            onChange={(v) => onChange({ gitCredentialId: v })}
+            teamId={teamId}
+            gitUrl={value.gitUrl}
+          />
         </>
       ) : (
         <div className="grid grid-cols-2 gap-4">
@@ -370,7 +370,7 @@ export function AppFormFields({
                       const rows = value.envRows.map((r, i) => i === ri ? { ...r, key: next } : r)
                       onChange({ envRows: rows })
                     }}
-                    className="font-mono text-xs w-40 shrink-0"
+                    className="h-8 font-mono text-xs w-48 shrink-0"
                   />
                   <Input
                     placeholder={row.description ?? "value"}
@@ -380,32 +380,30 @@ export function AppFormFields({
                       const rows = value.envRows.map((r, i) => i === ri ? { ...r, value: e.target.value } : r)
                       onChange({ envRows: rows })
                     }}
-                    className="font-mono text-xs"
+                    className="h-8 font-mono text-xs flex-1"
                   />
-                  <button
+                  <Button
                     type="button"
+                    size="sm"
+                    variant={row.isSecret ? "secondary" : "outline"}
                     onClick={() => {
                       const rows = value.envRows.map((r, i) => i === ri ? { ...r, isSecret: !r.isSecret } : r)
                       onChange({ envRows: rows })
                     }}
-                    className={cn(
-                      "text-xs shrink-0 px-2 py-1 rounded-md border transition-colors",
-                      row.isSecret
-                        ? "border-amber-500/50 text-amber-600 bg-amber-500/5 hover:bg-amber-500/10"
-                        : "border-border text-muted-foreground hover:text-foreground hover:bg-muted",
-                    )}
-                    aria-label={row.isSecret ? "Switch to plain variable" : "Switch to secret"}
+                    className={cn("h-8 shrink-0 text-xs", row.isSecret && "border border-amber-500/50 text-amber-600")}
                   >
                     Secret
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     type="button"
+                    size="sm"
+                    variant="ghost"
                     onClick={() => onChange({ envRows: value.envRows.filter((_, i) => i !== ri) })}
-                    className="text-muted-foreground hover:text-destructive text-xs shrink-0"
+                    className="h-8 shrink-0 text-muted-foreground hover:text-destructive px-2"
                     aria-label="Remove"
                   >
                     ✕
-                  </button>
+                  </Button>
                 </div>
                 {resolved !== null && (
                   <p className="text-xs text-muted-foreground pl-1">

--- a/apps/ui/src/components/app-form-fields.tsx
+++ b/apps/ui/src/components/app-form-fields.tsx
@@ -1,0 +1,451 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible"
+import { HelpTooltip } from "@/components/ui/tooltip"
+import { CredentialSelect } from "@/components/credential-select"
+import { cn } from "@/lib/utils"
+import { resolveTemplateVars, hasTemplateVars } from "@/lib/template"
+import type { GitCredential } from "@canette/types"
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type SlugState = "idle" | "checking" | "available" | "taken" | "invalid"
+
+export type AppFormValue = {
+  name: string
+  slug: string
+  slugState: SlugState
+  sourceType: "git" | "image"
+  gitUrl: string
+  gitBranch: string
+  appPath: string
+  imageUrl: string
+  imageTag: string
+  port: string
+  gitCredentialId: string
+  envRows: Array<{ key: string; value: string; isSecret: boolean; description?: string }>
+  canetteConfig: string
+}
+
+export function defaultAppFormValue(): AppFormValue {
+  return {
+    name: "",
+    slug: "",
+    slugState: "idle",
+    sourceType: "git",
+    gitUrl: "",
+    gitBranch: "main",
+    appPath: "",
+    imageUrl: "",
+    imageTag: "latest",
+    port: "3000",
+    gitCredentialId: "",
+    envRows: [],
+    canetteConfig: "",
+  }
+}
+
+export function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 63)
+}
+
+export function isValidEnvKey(key: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/.test(key)
+}
+
+function parseGitUrlHelper(raw: string): { gitUrl: string; branch: string; appPath: string } | null {
+  const gh = raw.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)\/tree\/([^/]+)(\/.*)?$/)
+  if (gh) return { gitUrl: gh[1], branch: gh[2], appPath: gh[3] ?? "" }
+  const gl = raw.match(/^(https:\/\/gitlab\.com\/[^/]+\/[^/]+)\/-\/tree\/([^/]+)(\/.*)?$/)
+  if (gl) return { gitUrl: gl[1], branch: gl[2], appPath: gl[3] ?? "" }
+  return null
+}
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+type AppFormFieldsProps = {
+  value: AppFormValue
+  onChange: (patch: Partial<AppFormValue>) => void
+  projectId: string
+  credentials: GitCredential[]
+  teamId?: string
+  // Template-only: slugMap for {{apps.X.slug}} resolution display in env values
+  slugMap?: Record<string, string>
+  // Enables parseGitUrl: detects branch/path from GitHub/GitLab browse URLs
+  parseGitUrl?: boolean
+  // When true, name changes auto-update slug (until user manually edits slug)
+  autoSlug?: boolean
+  autoFocus?: boolean
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function AppFormFields({
+  value,
+  onChange,
+  projectId,
+  credentials,
+  teamId,
+  slugMap,
+  parseGitUrl = false,
+  autoSlug = false,
+  autoFocus = false,
+}: AppFormFieldsProps) {
+  const slugEdited = useRef(false)
+  const [urlParsed, setUrlParsed] = useState(false)
+  const [envOpen, setEnvOpen] = useState(() => value.envRows.length > 0)
+  const [advancedOpen, setAdvancedOpen] = useState(() => !!value.canetteConfig)
+  const checkTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (checkTimer.current) clearTimeout(checkTimer.current)
+    const slug = value.slug
+
+    if (!slug) {
+      onChange({ slugState: "idle" })
+      return
+    }
+
+    const valid = /^[a-z0-9][a-z0-9-]{0,62}$/.test(slug) && !slug.endsWith("-")
+    if (!valid) {
+      onChange({ slugState: "invalid" })
+      return
+    }
+
+    onChange({ slugState: "checking" })
+    checkTimer.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/v1/projects/${projectId}/apps/slug-available?slug=${encodeURIComponent(slug)}`,
+          { credentials: "include" },
+        )
+        const data = await res.json()
+        onChange({ slugState: data.available ? "available" : "taken" })
+      } catch {
+        onChange({ slugState: "idle" })
+      }
+    }, 400)
+
+    return () => { if (checkTimer.current) clearTimeout(checkTimer.current) }
+  }, [value.slug, projectId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleNameChange(v: string) {
+    if (autoSlug && !slugEdited.current) {
+      onChange({ name: v, slug: toSlug(v) })
+    } else {
+      onChange({ name: v })
+    }
+  }
+
+  function handleSlugChange(v: string) {
+    slugEdited.current = true
+    onChange({ slug: v })
+  }
+
+  function handleGitUrlChange(raw: string) {
+    if (parseGitUrl) {
+      const parsed = parseGitUrlHelper(raw)
+      if (parsed) {
+        onChange({ gitUrl: parsed.gitUrl, gitBranch: parsed.branch, appPath: parsed.appPath })
+        setUrlParsed(true)
+        return
+      }
+      setUrlParsed(false)
+    }
+    onChange({ gitUrl: raw })
+  }
+
+  const slugHint = {
+    idle: null,
+    checking: <span className="text-muted-foreground">Checking…</span>,
+    available: <span className="text-green-500">Available</span>,
+    taken: <span className="text-destructive">Already taken in this project</span>,
+    invalid: <span className="text-destructive">Lowercase letters, numbers and hyphens only; cannot start or end with a hyphen</span>,
+  }[value.slugState]
+
+  return (
+    <div className="flex flex-col gap-5">
+
+      {/* Name */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="appName">Name</Label>
+        <Input
+          id="appName"
+          placeholder="My App"
+          value={value.name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          autoFocus={autoFocus}
+          required
+        />
+      </div>
+
+      {/* Slug */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="appSlug">
+          Slug
+          <span className="ml-2 text-xs text-muted-foreground font-normal">(used as container name)</span>
+        </Label>
+        <Input
+          id="appSlug"
+          placeholder="my-app"
+          value={value.slug}
+          onChange={(e) => handleSlugChange(e.target.value)}
+          className={cn(
+            value.slugState === "taken" || value.slugState === "invalid" ? "border-destructive" : "",
+            value.slugState === "available" ? "border-green-500" : "",
+          )}
+        />
+        <p className="text-xs min-h-[1rem]">{slugHint}</p>
+      </div>
+
+      {/* Source type toggle */}
+      <div className="flex flex-col gap-1.5">
+        <Label>Source</Label>
+        <div className="flex rounded-md border border-border overflow-hidden w-fit">
+          <button
+            type="button"
+            onClick={() => onChange({ sourceType: "git" })}
+            className={cn(
+              "px-4 py-1.5 text-sm transition-colors",
+              value.sourceType === "git"
+                ? "bg-foreground text-background font-medium"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted",
+            )}
+          >
+            Git
+          </button>
+          <button
+            type="button"
+            onClick={() => onChange({ sourceType: "image" })}
+            className={cn(
+              "px-4 py-1.5 text-sm transition-colors border-l border-border",
+              value.sourceType === "image"
+                ? "bg-foreground text-background font-medium"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted",
+            )}
+          >
+            Docker Image
+          </button>
+        </div>
+      </div>
+
+      {/* Git fields */}
+      {value.sourceType === "git" ? (
+        <>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="gitUrl">Git URL</Label>
+            <Input
+              id="gitUrl"
+              placeholder="https://github.com/org/repo"
+              value={value.gitUrl}
+              onChange={(e) => handleGitUrlChange(e.target.value)}
+              required
+            />
+            {urlParsed && (
+              <p className="text-xs text-muted-foreground">Branch and app path were detected from the URL.</p>
+            )}
+          </div>
+
+          <CredentialSelect
+            credentials={credentials}
+            value={value.gitCredentialId}
+            onChange={(v) => onChange({ gitCredentialId: v })}
+            teamId={teamId}
+            gitUrl={value.gitUrl}
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="gitBranch">Branch</Label>
+              <Input
+                id="gitBranch"
+                placeholder="main"
+                value={value.gitBranch}
+                onChange={(e) => onChange({ gitBranch: e.target.value })}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="appPath">
+                App path
+                <span className="ml-2 text-xs text-muted-foreground font-normal">optional</span>
+              </Label>
+              <Input
+                id="appPath"
+                placeholder="/"
+                value={value.appPath}
+                onChange={(e) => onChange({ appPath: e.target.value })}
+              />
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="imageUrl">Image</Label>
+            <Input
+              id="imageUrl"
+              placeholder="nginx"
+              value={value.imageUrl}
+              onChange={(e) => onChange({ imageUrl: e.target.value })}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="imageTag">Tag</Label>
+            <Input
+              id="imageTag"
+              placeholder="latest"
+              value={value.imageTag}
+              onChange={(e) => onChange({ imageTag: e.target.value })}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Port */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="appPort" className="flex items-center gap-1">
+          Port
+          <HelpTooltip>
+            <p className="mb-1.5">The same port your app uses locally, e.g. <code className="font-mono">http://localhost:3000</code> → port 3000.</p>
+            <p className="mb-1 font-medium">Common defaults:</p>
+            <ul className="space-y-0.5 text-muted-foreground">
+              <li>Next.js / Node / Rails → 3000</li>
+              <li>Vite → 5173</li>
+              <li>Django / Laravel → 8000</li>
+              <li>Flask / FastAPI → 5000</li>
+              <li>Spring Boot → 8080</li>
+            </ul>
+            <p className="mt-1.5 text-muted-foreground">
+              For Git apps, <code className="font-mono">PORT</code> is added automatically to the deployment.
+            </p>
+          </HelpTooltip>
+        </Label>
+        <Input
+          id="appPort"
+          type="number"
+          min={1}
+          max={65535}
+          value={value.port}
+          onChange={(e) => onChange({ port: e.target.value })}
+          className="w-32 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+      </div>
+
+      {/* Environment & Secrets (collapsible) */}
+      <Collapsible
+        open={envOpen}
+        onOpenChange={(open) => {
+          setEnvOpen(open)
+          if (open && value.envRows.length === 0) {
+            onChange({ envRows: [{ key: "", value: "", isSecret: false }] })
+          }
+        }}
+      >
+        <CollapsibleTrigger className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1.5">
+          <span>{envOpen ? "▾" : "▸"}</span>
+          <span>Environment &amp; Secrets</span>
+          {value.envRows.filter((r) => r.key).length > 0 && (
+            <span className="text-muted-foreground">({value.envRows.filter((r) => r.key).length})</span>
+          )}
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-3 flex flex-col gap-2">
+          {value.envRows.map((row, ri) => {
+            const resolved = !row.isSecret && slugMap && hasTemplateVars(row.value)
+              ? resolveTemplateVars(row.value, slugMap)
+              : null
+            return (
+              <div key={ri} className="flex flex-col gap-0.5">
+                <div className="flex gap-2 items-center">
+                  <Input
+                    placeholder="KEY"
+                    value={row.key}
+                    onChange={(e) => {
+                      const next = e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, "_")
+                      const rows = value.envRows.map((r, i) => i === ri ? { ...r, key: next } : r)
+                      onChange({ envRows: rows })
+                    }}
+                    className="font-mono text-xs w-40 shrink-0"
+                  />
+                  <Input
+                    placeholder={row.description ?? "value"}
+                    type={row.isSecret ? "password" : "text"}
+                    value={row.value}
+                    onChange={(e) => {
+                      const rows = value.envRows.map((r, i) => i === ri ? { ...r, value: e.target.value } : r)
+                      onChange({ envRows: rows })
+                    }}
+                    className="font-mono text-xs"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const rows = value.envRows.map((r, i) => i === ri ? { ...r, isSecret: !r.isSecret } : r)
+                      onChange({ envRows: rows })
+                    }}
+                    className={cn(
+                      "text-xs shrink-0 px-2 py-1 rounded-md border transition-colors",
+                      row.isSecret
+                        ? "border-amber-500/50 text-amber-600 bg-amber-500/5 hover:bg-amber-500/10"
+                        : "border-border text-muted-foreground hover:text-foreground hover:bg-muted",
+                    )}
+                    aria-label={row.isSecret ? "Switch to plain variable" : "Switch to secret"}
+                  >
+                    Secret
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onChange({ envRows: value.envRows.filter((_, i) => i !== ri) })}
+                    className="text-muted-foreground hover:text-destructive text-xs shrink-0"
+                    aria-label="Remove"
+                  >
+                    ✕
+                  </button>
+                </div>
+                {resolved !== null && (
+                  <p className="text-xs text-muted-foreground pl-1">
+                    → <code>{resolved}</code>
+                  </p>
+                )}
+              </div>
+            )
+          })}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onChange({ envRows: [...value.envRows, { key: "", value: "", isSecret: false }] })}
+            className="w-fit"
+          >
+            + Add
+          </Button>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Advanced configuration (collapsible) */}
+      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+        <CollapsibleTrigger className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1.5">
+          <span>{advancedOpen ? "▾" : "▸"}</span>
+          <span>Advanced configuration</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
+          <p className="text-xs text-muted-foreground">
+            Runtime, resource, and ingress settings as <code>canette.yaml</code>. Applied at deploy time; a repo&apos;s <code>canette.yaml</code> overrides these.
+          </p>
+          <Textarea
+            value={value.canetteConfig}
+            onChange={(e) => onChange({ canetteConfig: e.target.value })}
+            className="font-mono text-xs min-h-[120px]"
+            placeholder="# optional — leave blank to use platform defaults"
+          />
+        </CollapsibleContent>
+      </Collapsible>
+
+    </div>
+  )
+}

--- a/apps/ui/src/components/app-layout.tsx
+++ b/apps/ui/src/components/app-layout.tsx
@@ -2,22 +2,34 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { Menu, Plus } from "lucide-react"
+import { usePathname, useRouter } from "next/navigation"
+import { ChevronDown, Menu, Plus } from "lucide-react"
 import { Footer } from "@/components/footer"
 import { Sidebar } from "@/components/sidebar"
 import { UserMenu } from "@/components/user-menu"
 import { Breadcrumb } from "@/components/breadcrumb"
 import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { TeamProvider } from "@/lib/team-context"
 
-function headerAction(pathname: string): { label: string; href: string } | null {
+type HeaderAction = {
+  label: string
+  href: string
+  dropdownItems?: Array<{ label: string; href: string }>
+}
+
+function headerAction(pathname: string): HeaderAction | null {
   if (pathname === "/dashboard" || pathname === "/dashboard/") {
     return { label: "New project", href: "/dashboard/projects/new" }
   }
-  const projectMatch = pathname.match(/\/dashboard\/projects\/([^/]+)$/)
+  const projectMatch = pathname.match(/\/dashboard\/projects\/([^/]+)/)
   if (projectMatch && projectMatch[1] !== "new") {
-    return { label: "New app", href: `/dashboard/projects/${projectMatch[1]}/apps/new` }
+    const slug = projectMatch[1]
+    return {
+      label: "New app",
+      href: `/dashboard/projects/${slug}/apps/new`,
+      dropdownItems: [{ label: "From template", href: `/dashboard/projects/${slug}/from-template` }],
+    }
   }
   return null
 }
@@ -25,6 +37,7 @@ function headerAction(pathname: string): { label: string; href: string } | null 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false)
   const pathname = usePathname()
+  const router = useRouter()
   const action = headerAction(pathname)
 
   useEffect(() => {
@@ -59,13 +72,40 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           <Breadcrumb />
           <div className="ml-auto flex items-center gap-3">
             {action && (
-              <Button variant="outline" size="sm" asChild
-                className="text-muted-foreground hover:text-foreground gap-1.5">
-                <Link href={action.href}>
-                  <Plus size={14} />
-                  {action.label}
-                </Link>
-              </Button>
+              action.dropdownItems ? (
+                <div className="flex">
+                  <Button variant="outline" size="sm" asChild
+                    className="text-muted-foreground hover:text-foreground gap-1.5 rounded-r-none border-r-0">
+                    <Link href={action.href}>
+                      <Plus size={14} />
+                      {action.label}
+                    </Link>
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm"
+                        className="rounded-l-none px-2 text-muted-foreground hover:text-foreground">
+                        <ChevronDown size={14} />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {action.dropdownItems.map((item) => (
+                        <DropdownMenuItem key={item.href} onClick={() => router.push(item.href)}>
+                          {item.label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              ) : (
+                <Button variant="outline" size="sm" asChild
+                  className="text-muted-foreground hover:text-foreground gap-1.5">
+                  <Link href={action.href}>
+                    <Plus size={14} />
+                    {action.label}
+                  </Link>
+                </Button>
+              )
             )}
             <UserMenu />
           </div>

--- a/apps/ui/src/components/sidebar.tsx
+++ b/apps/ui/src/components/sidebar.tsx
@@ -115,21 +115,31 @@ function TeamSelector({
 
   return (
     <div className="relative">
-      <button
-        type="button"
-        onClick={() => hasMultiple && setOpen((o) => !o)}
-        className={cn(
-          "w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-semibold text-foreground transition-colors",
-          isTeamsPage && "bg-muted",
-          hasMultiple ? "hover:bg-muted/50 cursor-pointer" : "cursor-default"
-        )}
-      >
-        <Layers size={15} className="shrink-0" />
-        <span className="flex-1 text-left truncate">{name}</span>
+      <div className="flex items-center">
+        <Link
+          href="/dashboard/teams"
+          className={cn(
+            "flex-1 flex items-center gap-2 px-3 py-1.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted/50 min-w-0",
+            hasMultiple ? "rounded-l-md" : "rounded-md",
+            isTeamsPage && "bg-muted",
+          )}
+        >
+          <Layers size={15} className="shrink-0" />
+          <span className="truncate">{name}</span>
+        </Link>
         {hasMultiple && (
-          <ChevronDown size={13} className={cn("shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className={cn(
+              "px-1.5 py-1.5 rounded-r-md transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50",
+              open && "bg-muted/50 text-foreground",
+            )}
+          >
+            <ChevronDown size={13} className={cn("transition-transform", open && "rotate-180")} />
+          </button>
         )}
-      </button>
+      </div>
 
       {open && hasMultiple && (
         <>
@@ -186,6 +196,7 @@ export function Sidebar({
   const [teamProjects, setTeamProjects] = useState<Project[]>([])
   const [project, setProject] = useState<Project | null>(null)
   const [apps, setApps] = useState<App[]>([])
+  const [projectsOpen, setProjectsOpen] = useState(false)
 
   useEffect(() => {
     if (isAdmin) return
@@ -221,10 +232,6 @@ export function Sidebar({
   }, [isAdmin, selectedTeamId, teams, setSelectedTeamId])
 
   // Fetch projects for the selected team when at team root.
-  // Re-fetch the project list on every pathname change when at team root.
-  // Using pathname (not projectSlug) as a dep ensures a refresh happens any time
-  // the user lands on a non-project page — even via browser back — while keeping
-  // the existing list visible during project-page navigation to avoid flashing.
   useEffect(() => {
     if (isAdmin || !selectedTeamId) {
       setTeamProjects([])
@@ -243,6 +250,25 @@ export function Sidebar({
       .catch(() => {})
     return () => { cancelled = true }
   }, [pathname, isAdmin, selectedTeamId, projectSlug])
+
+  // Fetch team projects when inside a project (for the quick-switch dropdown).
+  useEffect(() => {
+    if (isAdmin || !project) return
+    let cancelled = false
+    fetch("/api/v1/projects", { credentials: "include" })
+      .then((r) => r.json())
+      .then((d) => {
+        if (!cancelled) {
+          const all: Project[] = d.items ?? []
+          setTeamProjects(all.filter((p) => p.teamId === project.teamId))
+        }
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [isAdmin, project])
+
+  // Close the projects dropdown on navigation.
+  useEffect(() => { setProjectsOpen(false) }, [pathname])
 
   const activeTeam = teams.find((t) => t.id === selectedTeamId) ?? teams[0]
 
@@ -288,11 +314,56 @@ export function Sidebar({
 
     nav = (
       <>
-        <Link href="/dashboard" title={collapsed ? "All projects" : undefined}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors">
-          <LayoutDashboard size={15} className="shrink-0" />
-          {!collapsed && <span className="truncate">Projects</span>}
-        </Link>
+        <div className="relative">
+          <div className="flex items-center">
+            <Link
+              href="/dashboard"
+              title={collapsed ? "All projects" : undefined}
+              className={cn(
+                "flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors min-w-0",
+                !collapsed && teamProjects.length > 0 ? "rounded-l-md flex-1" : "rounded-md",
+                collapsed && "justify-center",
+              )}
+            >
+              <LayoutDashboard size={15} className="shrink-0" />
+              {!collapsed && <span className="truncate">Projects</span>}
+            </Link>
+            {!collapsed && teamProjects.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setProjectsOpen((o) => !o)}
+                className={cn(
+                  "px-1.5 py-1.5 rounded-r-md transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50",
+                  projectsOpen && "bg-muted/50 text-foreground",
+                )}
+              >
+                <ChevronDown size={13} className={cn("transition-transform", projectsOpen && "rotate-180")} />
+              </button>
+            )}
+          </div>
+          {projectsOpen && !collapsed && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={() => setProjectsOpen(false)} />
+              <div className="absolute left-0 right-0 top-full mt-1 z-20 bg-popover border border-border rounded-md shadow-md py-1 max-h-60 overflow-y-auto">
+                {teamProjects.map((p) => (
+                  <Link
+                    key={p.id}
+                    href={`/dashboard/projects/${p.slug}`}
+                    onClick={() => setProjectsOpen(false)}
+                    className={cn(
+                      "block px-3 py-1.5 text-sm truncate transition-colors",
+                      p.slug === projectSlug
+                        ? "font-medium text-foreground"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
+                    )}
+                  >
+                    {p.name}
+                  </Link>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
         {project && !collapsed && (
           <Link href={`/dashboard/projects/${projectSlug}`}
             className="px-3 py-1 text-sm font-medium text-foreground truncate block rounded-md hover:bg-muted/50 transition-colors">
@@ -346,11 +417,11 @@ export function Sidebar({
             <span>New project</span>
           </Link>
         )}
-        {teamId && !(collapsed && pathname.startsWith("/dashboard/teams")) && (
+        {teamId && (
           <>
             <Divider />
             {!activeTeam?.isPersonal && <NavItem href={`/dashboard/teams/${teamId}/members`} label="Team Members" icon={Users} collapsed={collapsed} />}
-            <NavItem href={`/dashboard/teams/${teamId}/credentials`} label="Git Credentials" icon={Key} collapsed={collapsed} />            
+            <NavItem href={`/dashboard/teams/${teamId}/credentials`} label="Git Credentials" icon={Key} collapsed={collapsed} />
           </>
         )}
       </>

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -173,7 +173,7 @@ export const admin = {
 
 // Templates
 export const templates = {
-  parse: (body: { yaml?: string; url?: string }) =>
+  parse: (body: { yaml: string }) =>
     request<AppTemplate>("/templates/parse", { method: "POST", body: JSON.stringify(body) }),
 }
 

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -2,7 +2,7 @@
 // All requests go through Next.js rewrites → API server.
 // Never call the API directly from the browser with a hardcoded URL.
 
-import type { AdminProjectOverview, AdminTeamOverview, App, AppSecret, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanInfo, SyncResult, Team, TeamMember, User, UserDeletionImpact, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
+import type { AdminProjectOverview, AdminTeamOverview, App, AppSecret, AppTemplate, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanInfo, SyncResult, Team, TeamMember, User, UserDeletionImpact, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
 
 const base = "/api/v1"
 
@@ -169,6 +169,12 @@ export const admin = {
   getResourceDefaults: () => request<ResourceDefaults>("/admin/settings/resources"),
   resetUserPassword: (id: string) =>
     request<{ password: string }>(`/admin/users/${id}/reset-password`, { method: "POST" }),
+}
+
+// Templates
+export const templates = {
+  parse: (body: { yaml?: string; url?: string }) =>
+    request<AppTemplate>("/templates/parse", { method: "POST", body: JSON.stringify(body) }),
 }
 
 // Environment variables and secrets

--- a/apps/ui/src/lib/template.ts
+++ b/apps/ui/src/lib/template.ts
@@ -1,0 +1,21 @@
+// Resolve {{apps.<originalSlug>.slug}} references using the map of original → chosen slugs.
+export function resolveTemplateVars(
+  value: string,
+  slugMap: Record<string, string>,
+): string {
+  return value.replace(/\{\{apps\.([^.}]+)\.slug\}\}/g, (_, originalSlug) => {
+    return slugMap[originalSlug] ?? originalSlug
+  })
+}
+
+// Returns true if the value contains any unresolved template variable references.
+export function hasTemplateVars(value: string): boolean {
+  return /\{\{apps\.[^.}]+\.slug\}\}/.test(value)
+}
+
+// Build a slug map from an array of { originalSlug, chosenSlug } entries.
+export function buildSlugMap(
+  entries: Array<{ originalSlug: string; chosenSlug: string }>,
+): Record<string, string> {
+  return Object.fromEntries(entries.map(({ originalSlug, chosenSlug }) => [originalSlug, chosenSlug]))
+}

--- a/bun.lock
+++ b/bun.lock
@@ -17,11 +17,13 @@
         "better-auth": "^1.6.6",
         "hono": "4.12.18",
         "jose": "^6.2.3",
+        "js-yaml": "^4.1.1",
         "kysely": "^0.28.16",
         "pg": "^8.13.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/js-yaml": "^4.0.9",
         "@types/pg": "^8.11.0",
         "bun-types": "^1.3.13",
         "eslint": "^10.2.1",
@@ -604,6 +606,8 @@
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -215,6 +215,35 @@ export interface UserDeletionImpact {
   sharedTeamsReowned: string[]
 }
 
+// Template types
+
+export interface AppTemplate {
+  name: string
+  description?: string
+  apps: TemplateApp[]
+}
+
+export interface TemplateSecret {
+  name: string
+  description?: string
+}
+
+export interface TemplateApp {
+  name: string
+  slug: string
+  sourceType: AppSourceType
+  gitUrl?: string
+  gitBranch?: string
+  gitCredentialId?: string
+  appPath?: string
+  imageUrl?: string
+  imageTag?: string
+  port?: number
+  env?: Record<string, string>
+  secrets?: TemplateSecret[]
+  canetteConfig?: string
+}
+
 // API envelope types
 
 export interface ApiError {


### PR DESCRIPTION
## Summary

- Adds a **template wizard** UI at `/dashboard/projects/:slug/from-template` that parses a `canette-template.yaml` and walks the user through configuring and creating all apps in one flow
- Shared `AppFormFields` component extracted so the add-app and from-template forms stay in sync
- Template YAML is paste-only; paste UX improved with a clipboard icon button and a taller mono textarea
- API endpoint `POST /api/v1/templates/parse` accepts `{ yaml: string }` and returns a validated `AppTemplate`

## Test plan

- [ ] Paste a valid `canette-template.yaml` with 2+ apps → wizard advances to the configure step
- [ ] "Paste from clipboard" button populates the textarea
- [ ] Invalid / empty YAML shows an inline error, does not advance
- [ ] Completing the wizard creates all apps and redirects to the project page
- [ ] All API service tests pass (`bun test --cwd apps/api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)