### PR TITLE
feat: signup mode control, magic link login, and password reset

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -70,3 +70,19 @@ DEFAULT_MEMORY_LIMIT=512Mi
 # accessible at a different hostname than the UI.
 # Example: https://api.example.com
 WEBHOOK_BASE_URL=
+
+# ── Email provider (optional) ─────────────────────────────────────────────────
+# Enables magic-link login. Leave EMAIL_PROVIDER empty to disable.
+# Supported values: resend
+EMAIL_PROVIDER=
+# Resend API key — required when EMAIL_PROVIDER=resend.
+# Get one at https://resend.com (free tier available).
+RESEND_API_KEY=
+# From address for outgoing emails. Must match a verified domain in Resend.
+# For local testing you can use Resend's shared test domain: onboarding@resend.dev
+EMAIL_FROM=canette <noreply@example.com>
+
+# ── Signup access control ─────────────────────────────────────────────────────
+# Hard global disable for email sign-up (overrides the admin UI signup mode).
+# Leave false for local dev — the signup mode is managed in Admin → Settings.
+DISABLE_EMAIL_SIGNUP=false

--- a/apps/api/migrations/000008_signup_mode.down.sql
+++ b/apps/api/migrations/000008_signup_mode.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM admin_settings WHERE key = 'signup.mode';

--- a/apps/api/migrations/000008_signup_mode.up.sql
+++ b/apps/api/migrations/000008_signup_mode.up.sql
@@ -1,0 +1,2 @@
+INSERT INTO admin_settings (key, value, updated_at)
+VALUES ('signup.mode', 'open', CURRENT_TIMESTAMP);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,8 @@
     "jose": "^6.2.3",
     "js-yaml": "^4.1.1",
     "kysely": "^0.29.0",
-    "pg": "^8.13.0"
+    "pg": "^8.13.0",
+    "resend": "^6.12.3"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -49,17 +49,16 @@ export function createApp() {
 
     // Public: what signup mode is active and whether magic link is available.
     // Must be before auth middleware so the login page can read it unauthenticated.
+    // getSignupMode already folds in the DISABLE_EMAIL_SIGNUP Helm override.
     app.get("/api/v1/signup-settings", async (c) => {
-      if (process.env.DISABLE_EMAIL_SIGNUP === "true") {
-        return c.json({ mode: "disabled", magicLinkEnabled: emailProviderConfigured })
-      }
       const raw = await getSignupMode(db)
       const mode = raw === "open" || raw === "disabled" ? raw : "invite_code"
       return c.json({ mode, magicLinkEnabled: emailProviderConfigured })
     })
 
     // Signup interceptor — always registered before better-auth's catch-all.
-    // DISABLE_EMAIL_SIGNUP (Helm) is a hard override that cannot be changed at runtime.
+    // getSignupMode folds in the DISABLE_EMAIL_SIGNUP Helm override so callers
+    // only need to check the returned mode.
     //
     // The body is buffered immediately before any await. In Bun, the request body
     // stream is tied to the active read; awaiting an async operation (e.g. a DB call)
@@ -68,10 +67,6 @@ export function createApp() {
     // lets better-auth read the body normally.
     app.post("/api/auth/sign-up/email", async (c) => {
       const bodyText = await c.req.raw.text().catch(() => "")
-
-      if (process.env.DISABLE_EMAIL_SIGNUP === "true") {
-        return c.json({ error: "Sign-up is disabled on this instance", code: "SIGNUP_DISABLED" }, 403)
-      }
       const mode = await getSignupMode(db)
       if (mode === "disabled") {
         return c.json({ error: "Sign-up is disabled on this instance", code: "SIGNUP_DISABLED" }, 403)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
-import { auth } from "./auth/auth"
+import { auth, emailProviderConfigured } from "./auth/auth"
+import { db } from "./db/db"
+import { getSignupMode } from "./services/admin"
 import { projectsRouter } from "./routes/projects"
 import { teamsRouter } from "./routes/teams"
 import { appsRouter } from "./routes/apps"
@@ -45,13 +47,44 @@ export function createApp() {
     }),
     )
 
-    // Block email sign-up when disabled via DISABLE_EMAIL_SIGNUP env var.
-    // Must be registered before the better-auth catch-all so Hono matches it first.
-    if (process.env.DISABLE_EMAIL_SIGNUP === "true") {
-    app.post("/api/auth/sign-up/email", (c) =>
-        c.json({ error: "Sign-up is disabled on this instance", code: "SIGNUP_DISABLED" }, 403),
-    )
-    }
+    // Public: what signup mode is active and whether magic link is available.
+    // Must be before auth middleware so the login page can read it unauthenticated.
+    app.get("/api/v1/signup-settings", async (c) => {
+      if (process.env.DISABLE_EMAIL_SIGNUP === "true") {
+        return c.json({ mode: "disabled", magicLinkEnabled: emailProviderConfigured })
+      }
+      const raw = await getSignupMode(db)
+      const mode = raw === "open" || raw === "disabled" ? raw : "invite_code"
+      return c.json({ mode, magicLinkEnabled: emailProviderConfigured })
+    })
+
+    // Signup interceptor — always registered before better-auth's catch-all.
+    // DISABLE_EMAIL_SIGNUP (Helm) is a hard override that cannot be changed at runtime.
+    //
+    // The body is buffered immediately before any await. In Bun, the request body
+    // stream is tied to the active read; awaiting an async operation (e.g. a DB call)
+    // before reading the body marks the stream as used, causing better-auth to fail
+    // with ERR_BODY_ALREADY_USED. Buffering first and reconstructing the Request
+    // lets better-auth read the body normally.
+    app.post("/api/auth/sign-up/email", async (c) => {
+      const bodyText = await c.req.raw.text().catch(() => "")
+
+      if (process.env.DISABLE_EMAIL_SIGNUP === "true") {
+        return c.json({ error: "Sign-up is disabled on this instance", code: "SIGNUP_DISABLED" }, 403)
+      }
+      const mode = await getSignupMode(db)
+      if (mode === "disabled") {
+        return c.json({ error: "Sign-up is disabled on this instance", code: "SIGNUP_DISABLED" }, 403)
+      }
+      if (mode !== "open") {
+        const body = JSON.parse(bodyText || "{}") as Record<string, unknown>
+        if (body.inviteCode !== mode) {
+          return c.json({ error: "Invalid invite code", code: "INVALID_INVITE_CODE" }, 403)
+        }
+      }
+      const req = new Request(c.req.raw, { body: bodyText })
+      return auth.handler(req)
+    })
 
     // better-auth handles all /api/auth/** routes
     app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw))

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -1,9 +1,27 @@
 import { betterAuth } from "better-auth"
-import { admin } from "better-auth/plugins"
+import { admin, magicLink } from "better-auth/plugins"
 import { Pool } from "pg"
 import { passwordPolicyPlugin } from "./password"
+import { createEmailProvider } from "./email"
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+const emailProvider = createEmailProvider()
+export const emailProviderConfigured = emailProvider !== null
+
+const magicLinkPlugin = emailProvider
+  ? magicLink({
+      disableSignUp: true,
+      sendMagicLink: async ({ email, url }) => {
+        await emailProvider.send({
+          to: email,
+          subject: "Your canette sign-in link",
+          html: `<p>Click the link below to sign in to canette. The link expires in 15 minutes.</p><p><a href="${url}">${url}</a></p>`,
+          text: `Sign in to canette: ${url}\n\nThis link expires in 15 minutes.`,
+        })
+      },
+    })
+  : null
 
 export const coreAuthOptions = {
   advanced: {
@@ -11,9 +29,25 @@ export const coreAuthOptions = {
       generateId: () => crypto.randomUUID(),
     },
   },
-  plugins: [passwordPolicyPlugin(), admin({ adminRole: "admin", defaultRole: "developer" })],
+  plugins: [
+    passwordPolicyPlugin(),
+    admin({ adminRole: "admin", defaultRole: "developer" }),
+    ...(magicLinkPlugin ? [magicLinkPlugin] : []),
+  ],
   emailAndPassword: {
     enabled: true,
+    ...(emailProvider
+      ? {
+          sendResetPassword: async ({ user, url }: { user: { email: string }; url: string }) => {
+            await emailProvider.send({
+              to: user.email,
+              subject: "Reset your canette password",
+              html: `<p>Click the link below to reset your canette password. The link expires in 1 hour.</p><p><a href="${url}">${url}</a></p><p>If you did not request a password reset, you can ignore this email.</p>`,
+              text: `Reset your canette password: ${url}\n\nThis link expires in 1 hour. If you did not request a password reset, ignore this email.`,
+            })
+          },
+        }
+      : {}),
   },
   user: {
     additionalFields: {

--- a/apps/api/src/auth/email.ts
+++ b/apps/api/src/auth/email.ts
@@ -1,0 +1,44 @@
+import { Resend } from "resend"
+
+export interface EmailProvider {
+  send(opts: { to: string; subject: string; html: string; text: string }): Promise<void>
+}
+
+class ResendProvider implements EmailProvider {
+  private client: Resend
+  private from: string
+
+  constructor(apiKey: string, from: string) {
+    this.client = new Resend(apiKey)
+    this.from = from
+  }
+
+  async send(opts: { to: string; subject: string; html: string; text: string }): Promise<void> {
+    const { error } = await this.client.emails.send({
+      from: this.from,
+      to: opts.to,
+      subject: opts.subject,
+      html: opts.html,
+      text: opts.text,
+    })
+    if (error) throw new Error(`Resend error: ${error.message}`)
+  }
+}
+
+export function createEmailProvider(): EmailProvider | null {
+  const provider = process.env.EMAIL_PROVIDER ?? ""
+  if (!provider || provider === "none") return null
+
+  if (provider === "resend") {
+    const apiKey = process.env.RESEND_API_KEY
+    if (!apiKey) {
+      console.warn("EMAIL_PROVIDER=resend but RESEND_API_KEY is not set — magic link disabled")
+      return null
+    }
+    const from = process.env.EMAIL_FROM ?? "canette <noreply@example.com>"
+    return new ResendProvider(apiKey, from)
+  }
+
+  console.warn(`Unknown EMAIL_PROVIDER "${provider}" — magic link disabled`)
+  return null
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,13 +12,16 @@ import {
   getProjectsOverview,
   getResourceDefaults,
   getSecurityInfo,
+  getSignupMode,
   getTeamMembersForAdmin,
   getUserDeletionImpact,
   getWebhookSettings,
   listUsers,
   resetStuckBuilds,
+  setSignupMode,
   updateUserRole,
 } from "../services/admin"
+import { emailProviderConfigured } from "../auth/auth"
 import { listTeamsOverview, renameTeam, createTeam, deleteTeam, addMember, removeMember, findUserByEmail } from "../services/teams"
 import type { UserRole } from "@canette/types"
 
@@ -235,4 +238,27 @@ adminRouter.get("/settings/resources", (c) => {
 // GET /api/v1/admin/settings/webhooks
 adminRouter.get("/settings/webhooks", (c) => {
   return c.json(getWebhookSettings())
+})
+
+// Get signup mode (admin sees the actual invite code value)
+// GET /api/v1/admin/settings/signup
+adminRouter.get("/settings/signup", async (c) => {
+  const mode = await getSignupMode(db)
+  const helmDisabled = process.env.DISABLE_EMAIL_SIGNUP === "true"
+  return c.json({ mode, emailProviderConfigured, helmDisabled })
+})
+
+// Set signup mode
+// PUT /api/v1/admin/settings/signup
+adminRouter.put("/settings/signup", async (c) => {
+  const body = await c.req.json<{ mode: string }>()
+  try {
+    await setSignupMode(db, body.mode)
+    const mode = await getSignupMode(db)
+    const helmDisabled = process.env.DISABLE_EMAIL_SIGNUP === "true"
+    return c.json({ mode, emailProviderConfigured, helmDisabled })
+  } catch (e) {
+    if (e instanceof ServiceError) return c.json({ error: e.message, code: e.code }, e.status)
+    throw e
+  }
 })

--- a/apps/api/src/services/admin.ts
+++ b/apps/api/src/services/admin.ts
@@ -418,6 +418,28 @@ export function getWebhookSettings(): WebhookSettings {
   return { baseUrl: process.env.WEBHOOK_BASE_URL ?? "" }
 }
 
+// ── Signup mode ───────────────────────────────────────────────────────────────
+
+export async function getSignupMode(db: DB): Promise<string> {
+  const row = await db
+    .selectFrom("admin_settings")
+    .select("value")
+    .where("key", "=", "signup.mode")
+    .executeTakeFirst()
+  return row?.value ?? "open"
+}
+
+export async function setSignupMode(db: DB, mode: string): Promise<void> {
+  if (mode !== "open" && mode !== "disabled" && mode.length < 8) {
+    throw new ServiceError("Invite code must be at least 8 characters", "VALIDATION_ERROR", 400)
+  }
+  await db
+    .updateTable("admin_settings")
+    .set({ value: mode, updated_at: new Date().toISOString() })
+    .where("key", "=", "signup.mode")
+    .execute()
+}
+
 // ── Reset stuck builds ────────────────────────────────────────────────────────
 
 export async function resetStuckBuilds(db: DB): Promise<SyncResult> {

--- a/apps/api/src/services/admin.ts
+++ b/apps/api/src/services/admin.ts
@@ -421,6 +421,7 @@ export function getWebhookSettings(): WebhookSettings {
 // ── Signup mode ───────────────────────────────────────────────────────────────
 
 export async function getSignupMode(db: DB): Promise<string> {
+  if (process.env.DISABLE_EMAIL_SIGNUP === "true") return "disabled"
   const row = await db
     .selectFrom("admin_settings")
     .select("value")

--- a/apps/docs/content/docs/configuration/authentication.mdx
+++ b/apps/docs/content/docs/configuration/authentication.mdx
@@ -110,6 +110,13 @@ Magic link login lets users sign in without a password by receiving a one-time l
 
 When enabled, a **Sign in with magic link** button appears below the password form on the email login page. Magic links are for existing users only — they do not create new accounts. Users must first register via email/password, after which they can sign in with either method.
 
+#### Password reset
+
+A **Forgot password?** link is always shown on the email sign-in page. What happens when a user clicks it depends on whether an email provider is configured:
+
+- **With an email provider** — the user enters their email and receives a reset link. The link expires after 1 hour.
+- **Without an email provider** — the page displays a message directing the user to contact an administrator. Admins can reset any user's password from **Admin → Users → Reset password**, which generates a temporary password shown once.
+
 #### Configuring Resend
 
 [Resend](https://resend.com) is the first supported email provider and has a generous free tier.

--- a/apps/docs/content/docs/configuration/authentication.mdx
+++ b/apps/docs/content/docs/configuration/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication providers
-description: Configure GitHub OAuth, Google OAuth, and email login options.
+description: Configure GitHub OAuth, Google OAuth, email login, magic link, and signup access control.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout"
@@ -77,19 +77,67 @@ Once configured, a **Continue with Google** button appears on the login page.
 
 ## Email login
 
-Email/password login is always available unless explicitly disabled. Users sign in with their email address and password.
+Email/password login is always available. Users sign in with their email address and a password that meets the minimum policy (12+ characters, at least one uppercase, lowercase, and digit).
 
-### Disabling new sign-ups
+### Signup mode
 
-To prevent new users from creating accounts via email (while still allowing existing users to sign in), set:
+The signup mode controls how new users can register via email. It is configured in the admin UI under **Admin → Settings → Signup** and takes effect immediately — no restart or Helm upgrade required.
+
+| Mode | Behaviour |
+|------|-----------|
+| **Open** (default) | Anyone can create an account |
+| **Disabled** | No new registrations. Existing users can still sign in. |
+| **Invite code** | New users must supply a single static code at signup. Set the code (min. 8 characters) in the admin UI. |
+
+<Callout type="info">
+  Signup mode only applies to email registration. Social provider sign-ins (GitHub, Google) are not affected — a user signing in via OAuth for the first time will still have an account created regardless of the signup mode.
+</Callout>
+
+#### Hard disable via Helm
+
+For deployments where email signup should be permanently locked at the infrastructure level — regardless of what any admin sets in the UI — use the Helm override:
 
 ```yaml
 api:
   disableEmailSignup: true
 ```
 
-<Callout type="info">
-  This only blocks *new* registrations via email. Users who already have an account can still sign in. Social provider sign-ins are not affected — a user signing in with GitHub or Google for the first time will still have an account created automatically.
-</Callout>
+When this is set, the admin UI shows a notice that signup is globally disabled via Helm and the mode selector is locked. This is useful for SSO-only deployments or when you want ops to enforce the policy rather than trusting admin UI access.
 
-This is useful for closed-access deployments where user accounts are provisioned by an admin.
+### Magic link login
+
+Magic link login lets users sign in without a password by receiving a one-time link via email. It requires an email provider to be configured.
+
+When enabled, a **Sign in with magic link** button appears below the password form on the email login page. Magic links are for existing users only — they do not create new accounts. Users must first register via email/password, after which they can sign in with either method.
+
+#### Configuring Resend
+
+[Resend](https://resend.com) is the first supported email provider and has a generous free tier.
+
+1. Create an account at [resend.com](https://resend.com) and obtain an API key
+2. Verify your sending domain in the Resend dashboard
+3. Configure canette:
+
+```yaml
+api:
+  email:
+    provider: resend
+    resendApiKey: "<your-resend-api-key>"
+    from: "canette <noreply@yourdomain.com>"
+```
+
+Or reference a pre-existing Kubernetes Secret for the API key:
+
+```yaml
+api:
+  email:
+    provider: resend
+    from: "canette <noreply@yourdomain.com>"
+    resendApiKeyRef:
+      name: my-resend-secret
+      key: api-key
+```
+
+<Callout type="info">
+  Leave `api.email.provider` empty (the default) to disable magic link login entirely. Magic links require email delivery — without a configured provider, the button is not shown on the login page.
+</Callout>

--- a/apps/docs/content/docs/self-hosting/helm.mdx
+++ b/apps/docs/content/docs/self-hosting/helm.mdx
@@ -115,7 +115,10 @@ All service images default to `{image.repo}/{serviceName}:{image.tag}`, where `i
 | `api.defaultResources.cpuLimit` | `500m` | Default CPU limit for every app deployment |
 | `api.defaultResources.memoryLimit` | `512Mi` | Default memory limit for every app deployment |
 | `api.webhookBaseUrl` | `""` | Public base URL used when constructing webhook URLs registered with git providers. Leave empty to use the UI hostname. Set this if your API is accessible at a different hostname than the UI. |
-| `api.disableEmailSignup` | `false` | Disable new user sign-up via email. Existing users can still sign in. Set to `true` on closed-access deployments where accounts are created by an admin. |
+| `api.disableEmailSignup` | `false` | Hard global disable for email sign-up. Overrides the admin UI signup mode setting. Use for deployments where email accounts should be permanently locked at the infrastructure level. See [Authentication — Hard disable via Helm](/docs/configuration/authentication#hard-disable-via-helm). |
+| `api.email.provider` | `""` | Email provider for magic-link login. Supported values: `resend`. Leave empty to disable magic links. |
+| `api.email.resendApiKey` | `""` | Resend API key. Used when `api.email.provider=resend`. Use `api.email.resendApiKeyRef` to reference an existing Secret. |
+| `api.email.from` | `"canette <noreply@example.com>"` | From address for outgoing emails. Must match a verified sending domain in your email provider. |
 
 Resource values use standard Kubernetes quantity notation: `100m` (millicores), `256Mi` (mebibytes), `1` (full core or gigabyte).
 

--- a/apps/ui/.env.local.example
+++ b/apps/ui/.env.local.example
@@ -3,5 +3,10 @@
 # URL of the API server — used for server-side fetches and Next.js rewrites
 API_URL=http://localhost:3001
 
+# Internal API URL used by the Next.js server for SSR data fetching.
+# Defaults to http://localhost:3001 when not set.
+# In production (Kubernetes) this is set automatically to the in-cluster service URL.
+API_INTERNAL_URL=http://localhost:3001
+
 # Public API URL — used by client-side auth (must be reachable from the browser)
 NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/apps/ui/src/app/(authenticated)/admin/settings/page.tsx
+++ b/apps/ui/src/app/(authenticated)/admin/settings/page.tsx
@@ -2,26 +2,77 @@
 
 import { useEffect, useState } from "react"
 import { Separator } from "@/components/ui/separator"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { FormError } from "@/components/ui/form-error"
 import * as api from "@/lib/api"
-import type { ResourceDefaults, ScanInfo, WebhookSettings } from "@canette/types"
+import type { AdminSignupSettings, ResourceDefaults, ScanInfo, WebhookSettings } from "@canette/types"
 import { SkeletonText } from "@/components/ui/skeleton"
+
+type SignupModeValue = "open" | "disabled" | "invite_code"
 
 export default function AdminSettingsPage() {
   const [scanInfo, setScanInfo] = useState<ScanInfo | null>(null)
   const [webhookSettings, setWebhookSettings] = useState<WebhookSettings | null>(null)
   const [resourceDefaults, setResourceDefaults] = useState<ResourceDefaults | null>(null)
+  const [signupSettings, setSignupSettings] = useState<AdminSignupSettings | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
 
+  // Signup form state
+  const [signupMode, setSignupMode] = useState<SignupModeValue>("open")
+  const [inviteCode, setInviteCode] = useState("")
+  const [signupSaving, setSignupSaving] = useState(false)
+  const [signupError, setSignupError] = useState("")
+  const [signupSaved, setSignupSaved] = useState(false)
+
   useEffect(() => {
-    Promise.all([api.admin.getSecurityInfo(), api.admin.getWebhookSettings(), api.admin.getResourceDefaults()])
-      .then(([si, wh, rd]) => { setScanInfo(si); setWebhookSettings(wh); setResourceDefaults(rd) })
+    Promise.all([
+      api.admin.getSecurityInfo(),
+      api.admin.getWebhookSettings(),
+      api.admin.getResourceDefaults(),
+      api.admin.getSignupSettings(),
+    ])
+      .then(([si, wh, rd, ss]) => {
+        setScanInfo(si)
+        setWebhookSettings(wh)
+        setResourceDefaults(rd)
+        setSignupSettings(ss)
+
+        // Derive UI mode from the raw DB value
+        if (ss.mode === "open" || ss.mode === "disabled") {
+          setSignupMode(ss.mode)
+        } else {
+          setSignupMode("invite_code")
+          setInviteCode(ss.mode)
+        }
+      })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false))
   }, [])
 
+  async function saveSignupMode() {
+    setSignupSaving(true)
+    setSignupError("")
+    setSignupSaved(false)
+    try {
+      const effectiveMode = signupMode === "invite_code" ? inviteCode : signupMode
+      const updated = await api.admin.updateSignupSettings(effectiveMode)
+      setSignupSettings(updated)
+      setSignupSaved(true)
+      setTimeout(() => setSignupSaved(false), 3000)
+    } catch (e) {
+      setSignupError(e instanceof Error ? e.message : "Failed to save")
+    } finally {
+      setSignupSaving(false)
+    }
+  }
+
   if (loading) return <SkeletonText />
   if (error) return <p className="text-destructive text-sm">{error}</p>
+
+  const isHelmDisabled = signupSettings?.helmDisabled ?? false
 
   return (
     <>
@@ -31,6 +82,101 @@ export default function AdminSettingsPage() {
       </div>
 
       <div className="flex flex-col gap-8">
+
+        {/* Signup */}
+        <section>
+          <h2 className="text-sm font-medium mb-4">Signup</h2>
+          <div className="rounded-lg border border-border p-6 flex flex-col gap-4">
+            {isHelmDisabled ? (
+              <p className="text-sm text-muted-foreground">
+                Email signup is globally disabled via Helm (<code className="text-xs">api.disableEmailSignup=true</code>)
+                and cannot be changed at runtime.
+              </p>
+            ) : (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  Control how new users can register. Existing users can always log in regardless of this setting.
+                </p>
+
+                <div className="flex flex-col gap-3">
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1.5">Signup mode</p>
+                    <Select value={signupMode} onValueChange={(v) => setSignupMode(v as SignupModeValue)}>
+                      <SelectTrigger className="w-64">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="open">Open — anyone can sign up</SelectItem>
+                        <SelectItem value="disabled">Disabled — no new accounts</SelectItem>
+                        <SelectItem value="invite_code">Invite code</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {signupMode === "invite_code" && (
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1.5">Invite code (min. 8 characters)</p>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          value={inviteCode}
+                          onChange={(e) => setInviteCode(e.target.value)}
+                          placeholder="Enter invite code"
+                          className="w-72 font-mono"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            const chars = "ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
+                            const limit = Math.floor(256 / chars.length) * chars.length
+                            const out: string[] = []
+                            while (out.length < 16) {
+                              for (const b of crypto.getRandomValues(new Uint8Array(32)))
+                                if (b < limit && out.length < 16) out.push(chars[b % chars.length])
+                            }
+                            setInviteCode(out.join(""))
+                          }}
+                        >
+                          Generate
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-3 pt-1">
+                    <Button
+                      size="sm"
+                      onClick={saveSignupMode}
+                      disabled={signupSaving || (signupMode === "invite_code" && inviteCode.length < 8)}
+                    >
+                      {signupSaving ? "Saving…" : "Save"}
+                    </Button>
+                    {signupSaved && <span className="text-sm text-muted-foreground">Saved</span>}
+                  </div>
+
+                  {signupError && <FormError message={signupError} />}
+                </div>
+
+                <Separator />
+
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Email provider</p>
+                  <p className="text-sm font-mono">
+                    {signupSettings?.emailProviderConfigured
+                      ? <span className="text-green-600 dark:text-green-400">configured</span>
+                      : <span className="text-muted-foreground">none — magic link login disabled</span>}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Configured via Helm values (<code className="text-xs">api.email.provider</code>).
+                  </p>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+
+        <Separator />
 
         {/* Security */}
         <section>

--- a/apps/ui/src/app/login/email/email-form.tsx
+++ b/apps/ui/src/app/login/email/email-form.tsx
@@ -33,9 +33,9 @@ export function EmailForm({ callbackURL, initialSettings, forceSignIn }: { callb
     if (initialSettings) return
     getSignupSettings().then(s => {
       setSettings(s)
-      if (s.magicLinkEnabled) setFormMode("magic_link")
+      if (s.magicLinkEnabled && !forceSignIn) setFormMode("magic_link")
     }).catch(() => setSettings({ mode: "open", magicLinkEnabled: false }))
-  }, [])
+  }, [initialSettings, forceSignIn])
 
   const signupEnabled = settings !== null && settings.mode !== "disabled"
 

--- a/apps/ui/src/app/login/email/email-form.tsx
+++ b/apps/ui/src/app/login/email/email-form.tsx
@@ -37,7 +37,7 @@ export function EmailForm({ callbackURL, initialSettings, forceSignIn, forceSign
       setSettings(s)
       if (s.magicLinkEnabled && !forceSignIn && !forceSignUp) setFormMode("magic_link")
     }).catch(() => setSettings({ mode: "open", magicLinkEnabled: false }))
-  }, [initialSettings, forceSignIn])
+  }, [initialSettings, forceSignIn, forceSignUp])
 
   const signupEnabled = settings !== null && settings.mode !== "disabled"
 

--- a/apps/ui/src/app/login/email/email-form.tsx
+++ b/apps/ui/src/app/login/email/email-form.tsx
@@ -13,11 +13,13 @@ import { validatePassword } from "@/lib/password"
 import { getSignupSettings } from "@/lib/api"
 import type { SignupSettings } from "@canette/types"
 
-export function EmailForm({ callbackURL, initialSettings, forceSignIn }: { callbackURL?: string; initialSettings?: SignupSettings; forceSignIn?: boolean }) {
+export function EmailForm({ callbackURL, initialSettings, forceSignIn, forceSignUp }: { callbackURL?: string; initialSettings?: SignupSettings; forceSignIn?: boolean; forceSignUp?: boolean }) {
   const router = useRouter()
   const [settings, setSettings] = useState<SignupSettings | null>(initialSettings ?? null)
   const [formMode, setFormMode] = useState<"signin" | "signup" | "magic_link">(
-    !forceSignIn && initialSettings?.magicLinkEnabled ? "magic_link" : "signin"
+    forceSignIn ? "signin" :
+    forceSignUp ? "signup" :
+    initialSettings?.magicLinkEnabled ? "magic_link" : "signin"
   )
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
@@ -33,7 +35,7 @@ export function EmailForm({ callbackURL, initialSettings, forceSignIn }: { callb
     if (initialSettings) return
     getSignupSettings().then(s => {
       setSettings(s)
-      if (s.magicLinkEnabled && !forceSignIn) setFormMode("magic_link")
+      if (s.magicLinkEnabled && !forceSignIn && !forceSignUp) setFormMode("magic_link")
     }).catch(() => setSettings({ mode: "open", magicLinkEnabled: false }))
   }, [initialSettings, forceSignIn])
 
@@ -186,7 +188,7 @@ export function EmailForm({ callbackURL, initialSettings, forceSignIn }: { callb
             <div className="absolute inset-0 flex items-center">
               <span className="w-full border-t border-border" />
             </div>
-            <div className="relative flex justify-center text-xs uppercase">
+            <div className="relative flex justify-center text-xs">
               <span className="bg-card px-2 text-muted-foreground">or</span>
             </div>
           </div>

--- a/apps/ui/src/app/login/email/email-form.tsx
+++ b/apps/ui/src/app/login/email/email-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { signIn, signUp } from "@/lib/auth-client"
@@ -10,26 +10,60 @@ import { Label } from "@/components/ui/label"
 import { PasswordRequirements } from "@/components/ui/password-requirements"
 import { FormError } from "@/components/ui/form-error"
 import { validatePassword } from "@/lib/password"
+import { getSignupSettings } from "@/lib/api"
+import type { SignupSettings } from "@canette/types"
 
-export function EmailForm({ signupEnabled, callbackURL }: { signupEnabled: boolean; callbackURL?: string }) {
+export function EmailForm({ callbackURL, initialSettings, forceSignIn }: { callbackURL?: string; initialSettings?: SignupSettings; forceSignIn?: boolean }) {
   const router = useRouter()
-  const [mode, setMode] = useState<"signin" | "signup">("signin")
+  const [settings, setSettings] = useState<SignupSettings | null>(initialSettings ?? null)
+  const [formMode, setFormMode] = useState<"signin" | "signup" | "magic_link">(
+    !forceSignIn && initialSettings?.magicLinkEnabled ? "magic_link" : "signin"
+  )
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [inviteCode, setInviteCode] = useState("")
   const [loading, setLoading] = useState(false)
+  const [magicLinkSent, setMagicLinkSent] = useState(false)
   const [error, setError] = useState("")
-  // Reject non-relative callbackURLs to prevent open redirect attacks.
+
   const dest = callbackURL?.startsWith("/") ? callbackURL : "/dashboard"
+
+  useEffect(() => {
+    if (initialSettings) return
+    getSignupSettings().then(s => {
+      setSettings(s)
+      if (s.magicLinkEnabled) setFormMode("magic_link")
+    }).catch(() => setSettings({ mode: "open", magicLinkEnabled: false }))
+  }, [])
+
+  const signupEnabled = settings !== null && settings.mode !== "disabled"
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError("")
     setLoading(true)
     try {
-      if (mode === "signup") {
-        const result = await signUp.email({ name, email, password, callbackURL: dest })
-        if (result.error) { setError(result.error.message ?? "Sign up failed"); return }
+      if (formMode === "magic_link") {
+        const result = await signIn.magicLink({ email, callbackURL: dest })
+        if (result.error) { setError(result.error.message ?? "Failed to send magic link"); return }
+        setMagicLinkSent(true)
+        return
+      }
+      if (formMode === "signup") {
+        // Pass inviteCode in the request body when mode requires it
+        const extra = settings?.mode === "invite_code" ? { inviteCode } : {}
+        const result = await signUp.email({ name, email, password, callbackURL: dest, ...extra })
+        if (result.error) {
+          if (result.error.status === 403) {
+            setError(settings?.mode === "invite_code"
+              ? "Invalid invite code — double-check it or contact your administrator."
+              : "Sign-up is not allowed on this instance.")
+          } else {
+            setError(result.error.message ?? "Sign up failed")
+          }
+          return
+        }
       } else {
         const result = await signIn.email({ email, password, callbackURL: dest })
         if (result.error) { setError(result.error.message ?? "Sign in failed"); return }
@@ -42,15 +76,31 @@ export function EmailForm({ signupEnabled, callbackURL }: { signupEnabled: boole
     }
   }
 
-  function switchMode(next: "signin" | "signup") {
-    setMode(next)
+  function switchFormMode(next: "signin" | "signup" | "magic_link") {
+    setFormMode(next)
     setError("")
+    setMagicLinkSent(false)
+  }
+
+  if (magicLinkSent) {
+    return (
+      <>
+        <p className="text-center text-sm text-muted-foreground">
+          Check your email — we sent a sign-in link to <strong>{email}</strong>.
+        </p>
+        <p className="text-center text-sm text-muted-foreground">
+          <button type="button" onClick={() => switchFormMode("signin")} className="underline hover:text-foreground">
+            ← Back to sign in
+          </button>
+        </p>
+      </>
+    )
   }
 
   return (
     <>
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-        {mode === "signup" && (
+        {formMode === "signup" && (
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="name">Name</Label>
             <Input
@@ -73,42 +123,98 @@ export function EmailForm({ signupEnabled, callbackURL }: { signupEnabled: boole
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            autoComplete={mode === "signup" ? "email" : "username"}
+            autoComplete={formMode === "signup" ? "email" : "username"}
           />
         </div>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="password">Password</Label>
-          <Input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete={mode === "signup" ? "new-password" : "current-password"}
-          />
-          {mode === "signup" && <PasswordRequirements password={password} />}
-        </div>
+        {formMode !== "magic_link" && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Password</Label>
+              {formMode === "signin" && (
+                <Link href="/login/forgot-password" className="text-xs text-muted-foreground underline hover:text-foreground">
+                  Forgot password?
+                </Link>
+              )}
+            </div>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete={formMode === "signup" ? "new-password" : "current-password"}
+            />
+            {formMode === "signup" && <PasswordRequirements password={password} />}
+          </div>
+        )}
+        {formMode === "signup" && settings?.mode === "invite_code" && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="invite-code">Invite code</Label>
+            <Input
+              id="invite-code"
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              required
+              autoComplete="off"
+            />
+          </div>
+        )}
         {error && <FormError message={error} />}
         <Button
           type="submit"
           className="w-full"
-          disabled={loading || (mode === "signup" && validatePassword(password).length > 0)}
+          disabled={
+            loading ||
+            (formMode === "signup" && validatePassword(password).length > 0) ||
+            (formMode === "signup" && settings?.mode === "invite_code" && !inviteCode)
+          }
         >
-          {loading ? "…" : mode === "signup" ? "Create account" : "Sign in"}
+          {loading
+            ? "…"
+            : formMode === "signup"
+              ? "Create account"
+              : formMode === "magic_link"
+                ? "Send magic link"
+                : "Sign in"}
         </Button>
       </form>
 
-      {signupEnabled && (
+      {settings?.magicLinkEnabled && formMode !== "magic_link" && (
+        <>
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t border-border" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-card px-2 text-muted-foreground">or</span>
+            </div>
+          </div>
+          <Button variant="outline" className="w-full" onClick={() => switchFormMode("magic_link")}>
+            Sign in with magic link
+          </Button>
+        </>
+      )}
+
+      {formMode === "magic_link" && (
         <p className="text-center text-sm text-muted-foreground">
-          {mode === "signin" ? (
+          <button type="button" onClick={() => switchFormMode("signin")} className="underline hover:text-foreground">
+            ← Sign in with password instead
+          </button>
+        </p>
+      )}
+
+      {signupEnabled && formMode !== "magic_link" && (
+        <p className="text-center text-sm text-muted-foreground">
+          {formMode === "signin" ? (
             <>No account?{" "}
-              <button type="button" onClick={() => switchMode("signup")} className="underline hover:text-foreground">
+              <button type="button" onClick={() => switchFormMode("signup")} className="underline hover:text-foreground">
                 Sign up
               </button>
             </>
           ) : (
             <>Already have an account?{" "}
-              <button type="button" onClick={() => switchMode("signin")} className="underline hover:text-foreground">
+              <button type="button" onClick={() => switchFormMode("signin")} className="underline hover:text-foreground">
                 Sign in
               </button>
             </>

--- a/apps/ui/src/app/login/email/page.tsx
+++ b/apps/ui/src/app/login/email/page.tsx
@@ -1,27 +1,16 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CanetteLogo } from "@/components/canette-logo"
 import { EmailForm } from "./email-form"
-import type { SignupSettings } from "@canette/types"
+import { fetchSignupSettings } from "@/lib/api"
 
 export const dynamic = "force-dynamic"
-
-async function fetchSignupSettings(): Promise<SignupSettings | undefined> {
-  const base = process.env.API_INTERNAL_URL ?? "http://localhost:3001"
-  try {
-    const res = await fetch(`${base}/api/v1/signup-settings`, { cache: "no-store" })
-    if (!res.ok) return undefined
-    return res.json()
-  } catch {
-    return undefined
-  }
-}
 
 export default async function EmailLoginPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string>>
 }) {
-  const [{ callbackURL, reset }, initialSettings] = await Promise.all([
+  const [{ callbackURL, reset, signup }, initialSettings] = await Promise.all([
     searchParams,
     fetchSignupSettings(),
   ])
@@ -34,7 +23,7 @@ export default async function EmailLoginPage({
             <CanetteLogo className="size-16 p-1" />
           </div>
           <CardTitle className="text-2xl font-bold tracking-tight">canette</CardTitle>
-          <CardDescription>Sign in with your email</CardDescription>
+          <CardDescription>Continue with email</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           {reset && (
@@ -42,7 +31,12 @@ export default async function EmailLoginPage({
               Password updated — sign in with your new password.
             </p>
           )}
-          <EmailForm callbackURL={callbackURL} initialSettings={initialSettings} forceSignIn={!!reset} />
+          <EmailForm
+            callbackURL={callbackURL}
+            initialSettings={initialSettings}
+            forceSignIn={!!reset}
+            forceSignUp={!!signup && !reset}
+          />
         </CardContent>
       </Card>
     </main>

--- a/apps/ui/src/app/login/forgot-password/forgot-password-form.tsx
+++ b/apps/ui/src/app/login/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { requestPasswordReset } from "@/lib/auth-client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { FormError } from "@/components/ui/form-error"
+
+export function ForgotPasswordForm({ emailEnabled }: { emailEnabled: boolean }) {
+  const [email, setEmail] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState("")
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+    try {
+      const result = await requestPasswordReset({
+        email,
+        redirectTo: `${window.location.origin}/login/reset-password`,
+      })
+      if (result.error) {
+        setError(result.error.message ?? "Failed to send reset email")
+        return
+      }
+      setSent(true)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Something went wrong")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!emailEnabled) {
+    return (
+      <>
+        <p className="text-sm text-muted-foreground text-center">
+          No email provider is configured on this instance. Contact your administrator to reset your password.
+        </p>
+        <p className="text-center text-sm text-muted-foreground">
+          <Link href="/login/email" className="underline hover:text-foreground">← Back to sign in</Link>
+        </p>
+      </>
+    )
+  }
+
+  if (sent) {
+    return (
+      <>
+        <p className="text-sm text-muted-foreground text-center">
+          If <strong>{email}</strong> has an account, a reset link is on its way. Check your inbox.
+        </p>
+        <p className="text-center text-sm text-muted-foreground">
+          <Link href="/login/email" className="underline hover:text-foreground">← Back to sign in</Link>
+        </p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            autoComplete="email"
+          />
+        </div>
+        {error && <FormError message={error} />}
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? "Sending…" : "Send reset link"}
+        </Button>
+      </form>
+      <p className="text-center text-sm text-muted-foreground">
+        <Link href="/login/email" className="underline hover:text-foreground">← Back to sign in</Link>
+      </p>
+    </>
+  )
+}

--- a/apps/ui/src/app/login/forgot-password/forgot-password-form.tsx
+++ b/apps/ui/src/app/login/forgot-password/forgot-password-form.tsx
@@ -39,7 +39,7 @@ export function ForgotPasswordForm({ emailEnabled }: { emailEnabled: boolean }) 
     return (
       <>
         <p className="text-sm text-muted-foreground text-center">
-          No email provider is configured on this instance. Contact your administrator to reset your password.
+          Contact your administrator to reset your password.
         </p>
         <p className="text-center text-sm text-muted-foreground">
           <Link href="/login/email" className="underline hover:text-foreground">← Back to sign in</Link>

--- a/apps/ui/src/app/login/forgot-password/page.tsx
+++ b/apps/ui/src/app/login/forgot-password/page.tsx
@@ -1,20 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CanetteLogo } from "@/components/canette-logo"
 import { ForgotPasswordForm } from "./forgot-password-form"
-import type { SignupSettings } from "@canette/types"
+import { fetchSignupSettings } from "@/lib/api"
 
 export const dynamic = "force-dynamic"
-
-async function fetchSignupSettings(): Promise<SignupSettings | undefined> {
-  const base = process.env.API_INTERNAL_URL ?? "http://localhost:3001"
-  try {
-    const res = await fetch(`${base}/api/v1/signup-settings`, { cache: "no-store" })
-    if (!res.ok) return undefined
-    return res.json()
-  } catch {
-    return undefined
-  }
-}
 
 export default async function ForgotPasswordPage() {
   const settings = await fetchSignupSettings()

--- a/apps/ui/src/app/login/forgot-password/page.tsx
+++ b/apps/ui/src/app/login/forgot-password/page.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CanetteLogo } from "@/components/canette-logo"
-import { EmailForm } from "./email-form"
+import { ForgotPasswordForm } from "./forgot-password-form"
 import type { SignupSettings } from "@canette/types"
 
 export const dynamic = "force-dynamic"
@@ -16,15 +16,9 @@ async function fetchSignupSettings(): Promise<SignupSettings | undefined> {
   }
 }
 
-export default async function EmailLoginPage({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string>>
-}) {
-  const [{ callbackURL, reset }, initialSettings] = await Promise.all([
-    searchParams,
-    fetchSignupSettings(),
-  ])
+export default async function ForgotPasswordPage() {
+  const settings = await fetchSignupSettings()
+  const emailEnabled = settings?.magicLinkEnabled ?? false
 
   return (
     <main className="min-h-screen flex items-center justify-center p-4">
@@ -33,16 +27,15 @@ export default async function EmailLoginPage({
           <div className="flex justify-center mb-2">
             <CanetteLogo className="size-16 p-1" />
           </div>
-          <CardTitle className="text-2xl font-bold tracking-tight">canette</CardTitle>
-          <CardDescription>Sign in with your email</CardDescription>
+          <CardTitle className="text-2xl font-bold tracking-tight">Reset password</CardTitle>
+          <CardDescription>
+            {emailEnabled
+              ? "Enter your email and we'll send you a reset link."
+              : "Password resets require administrator assistance."}
+          </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          {reset && (
-            <p className="text-sm text-center text-muted-foreground rounded-md border border-border px-3 py-2">
-              Password updated — sign in with your new password.
-            </p>
-          )}
-          <EmailForm callbackURL={callbackURL} initialSettings={initialSettings} forceSignIn={!!reset} />
+          <ForgotPasswordForm emailEnabled={emailEnabled} />
         </CardContent>
       </Card>
     </main>

--- a/apps/ui/src/app/login/login-form.tsx
+++ b/apps/ui/src/app/login/login-form.tsx
@@ -12,11 +12,13 @@ export function LoginForm({
   githubEnabled,
   googleEnabled,
   emailEnabled,
+  signupEnabled,
   callbackURL,
 }: {
   githubEnabled: boolean
   googleEnabled: boolean
   emailEnabled: boolean
+  signupEnabled?: boolean
   callbackURL?: string
 }) {
   const [githubLoading, setGithubLoading] = useState(false)
@@ -61,10 +63,13 @@ export function LoginForm({
       )}
 
       {showDivider && (
-        <div className="flex items-center gap-3">
-          <div className="flex-1 border-t border-border" />
-          <span className="text-xs text-muted-foreground">or</span>
-          <div className="flex-1 border-t border-border" />
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-card px-2 text-muted-foreground">or</span>
+          </div>
         </div>
       )}
 
@@ -72,6 +77,18 @@ export function LoginForm({
         <Button asChild variant="outline" className="w-full">
           <Link href={emailHref}>Sign in with email</Link>
         </Button>
+      )}
+
+      {emailEnabled && signupEnabled && (
+        <p className="text-center text-sm text-muted-foreground">
+          No account?{" "}
+          <Link
+            href={callbackURL ? `/login/email?signup=1&callbackURL=${encodeURIComponent(callbackURL)}` : "/login/email?signup=1"}
+            className="underline hover:text-foreground"
+          >
+            Sign up
+          </Link>
+        </p>
       )}
     </div>
   )

--- a/apps/ui/src/app/login/login-form.tsx
+++ b/apps/ui/src/app/login/login-form.tsx
@@ -11,15 +11,18 @@ import { GoogleIcon } from "@/components/icons/google-icon"
 export function LoginForm({
   githubEnabled,
   googleEnabled,
+  emailEnabled,
   callbackURL,
 }: {
   githubEnabled: boolean
   googleEnabled: boolean
+  emailEnabled: boolean
   callbackURL?: string
 }) {
   const [githubLoading, setGithubLoading] = useState(false)
   const [googleLoading, setGoogleLoading] = useState(false)
   const hasSocialProviders = githubEnabled || googleEnabled
+  const showDivider = hasSocialProviders && emailEnabled
   // Reject non-relative callbackURLs to prevent open redirect attacks.
   const dest = callbackURL?.startsWith("/") ? callbackURL : "/dashboard"
   const emailHref = callbackURL
@@ -57,7 +60,7 @@ export function LoginForm({
         </Button>
       )}
 
-      {hasSocialProviders && (
+      {showDivider && (
         <div className="flex items-center gap-3">
           <div className="flex-1 border-t border-border" />
           <span className="text-xs text-muted-foreground">or</span>
@@ -65,9 +68,11 @@ export function LoginForm({
         </div>
       )}
 
-      <Button asChild variant="outline" className="w-full">
-        <Link href={emailHref}>Sign in with email</Link>
-      </Button>
+      {emailEnabled && (
+        <Button asChild variant="outline" className="w-full">
+          <Link href={emailHref}>Sign in with email</Link>
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CanetteLogo } from "@/components/canette-logo"
 import { LoginForm } from "./login-form"
+import { fetchSignupSettings } from "@/lib/api"
 
 export const dynamic = "force-dynamic"
 
@@ -12,7 +13,11 @@ export default async function LoginPage({
   const githubEnabled = !!process.env.GITHUB_LOGIN_ENABLED && process.env.GITHUB_LOGIN_ENABLED !== "false"
   const googleEnabled = !!process.env.GOOGLE_LOGIN_ENABLED && process.env.GOOGLE_LOGIN_ENABLED !== "false"
   const emailEnabled = process.env.EMAIL_LOGIN_ENABLED !== "false"
-  const { callbackURL } = await searchParams
+  const [{ callbackURL }, signupSettings] = await Promise.all([
+    searchParams,
+    emailEnabled ? fetchSignupSettings() : Promise.resolve(undefined),
+  ])
+  const signupEnabled = signupSettings?.mode !== "disabled"
 
   return (
     <main className="min-h-screen flex items-center justify-center p-4">
@@ -25,7 +30,7 @@ export default async function LoginPage({
           <CardDescription>Kubernetes Push-to-deploy Platform</CardDescription>
         </CardHeader>
         <CardContent>
-          <LoginForm githubEnabled={githubEnabled} googleEnabled={googleEnabled} emailEnabled={emailEnabled} callbackURL={callbackURL} />
+          <LoginForm githubEnabled={githubEnabled} googleEnabled={googleEnabled} emailEnabled={emailEnabled} signupEnabled={signupEnabled} callbackURL={callbackURL} />
         </CardContent>
       </Card>
     </main>

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -11,6 +11,7 @@ export default async function LoginPage({
 }) {
   const githubEnabled = !!process.env.GITHUB_LOGIN_ENABLED && process.env.GITHUB_LOGIN_ENABLED !== "false"
   const googleEnabled = !!process.env.GOOGLE_LOGIN_ENABLED && process.env.GOOGLE_LOGIN_ENABLED !== "false"
+  const emailEnabled = process.env.EMAIL_LOGIN_ENABLED !== "false"
   const { callbackURL } = await searchParams
 
   return (
@@ -24,7 +25,7 @@ export default async function LoginPage({
           <CardDescription>Kubernetes Push-to-deploy Platform</CardDescription>
         </CardHeader>
         <CardContent>
-          <LoginForm githubEnabled={githubEnabled} googleEnabled={googleEnabled} callbackURL={callbackURL} />
+          <LoginForm githubEnabled={githubEnabled} googleEnabled={googleEnabled} emailEnabled={emailEnabled} callbackURL={callbackURL} />
         </CardContent>
       </Card>
     </main>

--- a/apps/ui/src/app/login/reset-password/page.tsx
+++ b/apps/ui/src/app/login/reset-password/page.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { CanetteLogo } from "@/components/canette-logo"
+import { ResetPasswordForm } from "./reset-password-form"
+
+export const dynamic = "force-dynamic"
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string>>
+}) {
+  const { token } = await searchParams
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-2">
+            <CanetteLogo className="size-16 p-1" />
+          </div>
+          <CardTitle className="text-2xl font-bold tracking-tight">New password</CardTitle>
+          <CardDescription>Choose a strong password for your account.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <ResetPasswordForm token={token} />
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/apps/ui/src/app/login/reset-password/reset-password-form.tsx
+++ b/apps/ui/src/app/login/reset-password/reset-password-form.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { resetPassword } from "@/lib/auth-client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { PasswordRequirements } from "@/components/ui/password-requirements"
+import { FormError } from "@/components/ui/form-error"
+import { validatePassword } from "@/lib/password"
+
+export function ResetPasswordForm({ token }: { token?: string }) {
+  const router = useRouter()
+  const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+
+  if (!token) {
+    return (
+      <>
+        <p className="text-sm text-muted-foreground text-center">
+          This reset link is invalid or has expired. Request a new one.
+        </p>
+        <Button asChild variant="outline" className="w-full">
+          <Link href="/login/forgot-password">Request new link</Link>
+        </Button>
+      </>
+    )
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+    try {
+      const result = await resetPassword({ newPassword: password, token })
+      if (result.error) {
+        if (result.error.status === 400 || result.error.status === 404) {
+          setError("This reset link has expired or already been used. Please request a new one.")
+        } else {
+          setError(result.error.message ?? "Failed to reset password")
+        }
+        return
+      }
+      router.push("/login/email?reset=1")
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Something went wrong")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="password">New password</Label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+        />
+        <PasswordRequirements password={password} />
+      </div>
+      {error && <FormError message={error} />}
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={loading || validatePassword(password).length > 0}
+      >
+        {loading ? "Saving…" : "Set new password"}
+      </Button>
+    </form>
+  )
+}

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -185,6 +185,18 @@ export async function getSignupSettings(): Promise<SignupSettings> {
   return res.json()
 }
 
+// Server-side variant — uses the internal API URL, for use in Server Components only
+export async function fetchSignupSettings(): Promise<SignupSettings | undefined> {
+  const apiBase = process.env.API_INTERNAL_URL ?? "http://localhost:3001"
+  try {
+    const res = await fetch(`${apiBase}/api/v1/signup-settings`, { cache: "no-store" })
+    if (!res.ok) return undefined
+    return res.json()
+  } catch {
+    return undefined
+  }
+}
+
 // Templates
 export const templates = {
   parse: (body: { yaml: string }) =>

--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -2,7 +2,7 @@
 // All requests go through Next.js rewrites → API server.
 // Never call the API directly from the browser with a hardcoded URL.
 
-import type { AdminProjectOverview, AdminTeamOverview, App, AppSecret, AppTemplate, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanInfo, SyncResult, Team, TeamMember, User, UserDeletionImpact, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
+import type { AdminProjectOverview, AdminSignupSettings, AdminTeamOverview, App, AppSecret, AppTemplate, BuildLog, Deployment, EnvVar, GitCredential, GitCredentialType, GitProvider, PaginatedResponse, Project, ResourceDefaults, ScanInfo, SignupSettings, SyncResult, Team, TeamMember, User, UserDeletionImpact, UserRole, WebhookConfig, WebhookSettings } from "@canette/types"
 
 const base = "/api/v1"
 
@@ -171,8 +171,18 @@ export const admin = {
   getSecurityInfo: () => request<ScanInfo>("/admin/settings/security"),
   getWebhookSettings: () => request<WebhookSettings>("/admin/settings/webhooks"),
   getResourceDefaults: () => request<ResourceDefaults>("/admin/settings/resources"),
+  getSignupSettings: () => request<AdminSignupSettings>("/admin/settings/signup"),
+  updateSignupSettings: (mode: string) =>
+    request<AdminSignupSettings>("/admin/settings/signup", { method: "PUT", body: JSON.stringify({ mode }) }),
   resetUserPassword: (id: string) =>
     request<{ password: string }>(`/admin/users/${id}/reset-password`, { method: "POST" }),
+}
+
+// Public signup settings — no auth required, used by the login/signup page
+export async function getSignupSettings(): Promise<SignupSettings> {
+  const res = await fetch(`${base}/signup-settings`)
+  if (!res.ok) return { mode: "open", magicLinkEnabled: false }
+  return res.json()
 }
 
 // Templates

--- a/apps/ui/src/lib/auth-client.ts
+++ b/apps/ui/src/lib/auth-client.ts
@@ -1,10 +1,10 @@
 import { createAuthClient } from "better-auth/react"
-import { adminClient } from "better-auth/client/plugins"
+import { adminClient, magicLinkClient } from "better-auth/client/plugins"
 
 export const authClient = createAuthClient({
   // No baseURL — better-auth uses the current page origin, which Next.js
   // proxies to the API via the /api rewrite in next.config.ts.
-  plugins: [adminClient()],
+  plugins: [adminClient(), magicLinkClient()],
 })
 
-export const { signIn, signOut, signUp, useSession, changePassword } = authClient
+export const { signIn, signOut, signUp, useSession, changePassword, requestPasswordReset, resetPassword } = authClient

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "js-yaml": "^4.1.1",
         "kysely": "^0.29.0",
         "pg": "^8.13.0",
+        "resend": "^6.12.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -505,6 +506,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -960,6 +963,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1485,6 +1490,8 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
@@ -1569,6 +1576,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resend": ["resend@6.12.3", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.92.2" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw=="],
+
     "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1651,6 +1660,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
@@ -1690,6 +1701,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svix": ["svix@1.92.2", "", { "dependencies": { "standardwebhooks": "1.0.0" } }, "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/charts/canette/templates/api/deployment.yaml
+++ b/charts/canette/templates/api/deployment.yaml
@@ -146,6 +146,22 @@ spec:
               value: {{ .Chart.AppVersion | quote }}
             - name: DISABLE_EMAIL_SIGNUP
               value: {{ if .Values.api.disableEmailSignup }}"true"{{ else }}"false"{{ end }}
+            - name: EMAIL_PROVIDER
+              value: {{ .Values.api.email.provider | quote }}
+            - name: EMAIL_FROM
+              value: {{ .Values.api.email.from | quote }}
+            {{- if .Values.api.email.provider }}
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- if ((.Values.api.email.resendApiKeyRef).name) }}
+                  name: {{ .Values.api.email.resendApiKeyRef.name }}
+                  key: {{ .Values.api.email.resendApiKeyRef.key }}
+                  {{- else }}
+                  name: canette-api-secrets
+                  key: resend-api-key
+                  {{- end }}
+            {{- end }}
             - name: MCP_JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/canette/templates/api/secret.yaml
+++ b/charts/canette/templates/api/secret.yaml
@@ -57,3 +57,6 @@ stringData:
   github-app-private-key: {{ .Values.api.githubApp.privateKey | quote }}
   {{- end }}
   {{- end }}
+  {{- if and .Values.api.email.resendApiKey (not (.Values.api.email.resendApiKeyRef).name) }}
+  resend-api-key: {{ .Values.api.email.resendApiKey | quote }}
+  {{- end }}

--- a/charts/canette/templates/ui/deployment.yaml
+++ b/charts/canette/templates/ui/deployment.yaml
@@ -35,14 +35,14 @@ spec:
               value: "3000"
             - name: API_URL
               value: {{ include "canette.apiURL" . | quote }}
+            - name: API_INTERNAL_URL
+              value: {{ include "canette.apiURL" . | quote }}
             - name: GITHUB_LOGIN_ENABLED
               value: {{ if .Values.api.githubClientId }}"true"{{ else }}"false"{{ end }}
             - name: GITHUB_APP_ENABLED
               value: {{ if .Values.api.githubApp.appId }}"true"{{ else }}"false"{{ end }}
             - name: GOOGLE_LOGIN_ENABLED
               value: {{ if .Values.api.googleClientId }}"true"{{ else }}"false"{{ end }}
-            - name: EMAIL_SIGNUP_ENABLED
-              value: {{ if .Values.api.disableEmailSignup }}"false"{{ else }}"true"{{ end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/canette/templates/ui/deployment.yaml
+++ b/charts/canette/templates/ui/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: {{ if .Values.api.githubApp.appId }}"true"{{ else }}"false"{{ end }}
             - name: GOOGLE_LOGIN_ENABLED
               value: {{ if .Values.api.googleClientId }}"true"{{ else }}"false"{{ end }}
+            - name: EMAIL_LOGIN_ENABLED
+              value: {{ if .Values.api.disableEmailSignup }}"false"{{ else }}"true"{{ end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -359,10 +359,26 @@ api:
   # Leave empty to use the UI hostname. Set this if your API is accessible at a different
   # hostname than the UI (e.g. when only the API is publicly exposed).
   webhookBaseUrl: ""
-  # Disable email/password sign-up. Existing users can still sign in with email.
-  # Set to true on closed-access deployments where user accounts are created by an admin.
-  # Defaults to false (sign-up is open).
+  # Hard global disable for email/password sign-up.
+  # Overrides the admin UI signup mode setting — use for deployments where email
+  # accounts are undesirable entirely (e.g. SSO-only). Existing users can still
+  # sign in with email when this is false; the fine-grained mode (open/disabled/invite)
+  # is managed via the admin settings UI and stored in the database.
   disableEmailSignup: false
+
+  # Email provider for magic-link login. Leave provider empty to disable magic links.
+  # Supported providers: resend
+  email:
+    provider: ""
+    # Resend API key. Can also be supplied via a pre-existing secret with resendApiKeyRef.
+    resendApiKey: ""
+    resendApiKeyRef:
+      # name: my-secret
+      # key: resend-api-key
+      name: ""
+      key: ""
+    # From address used in outgoing emails.
+    from: "canette <noreply@example.com>"
   resources:
     requests:
       cpu: 100m

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -204,6 +204,17 @@ export interface ResourceDefaults {
   memoryLimit: string
 }
 
+export interface SignupSettings {
+  mode: "open" | "disabled" | "invite_code"
+  magicLinkEnabled: boolean
+}
+
+export interface AdminSignupSettings {
+  mode: string
+  emailProviderConfigured: boolean
+  helmDisabled: boolean
+}
+
 export interface SyncResult {
   synced: number
   message: string


### PR DESCRIPTION
## Summary

- **Signup mode control** (closes #37): admin-configurable registration policy stored in `admin_settings` — open, disabled, or invite code. Helm `api.disableEmailSignup` remains as a hard infrastructure-level override that locks the admin UI.
- **Magic link login**: pluggable `EmailProvider` abstraction with Resend as the first implementation. Magic link is sign-in only (`disableSignUp: true`) so it cannot bypass signup mode controls. Defaults to magic link on the email login page when a provider is configured.
- **Password reset**: `sendResetPassword` wired when an email provider is present. Forgot password page shows a "contact admin" fallback when no provider is configured. Post-reset redirect forces password mode even when magic link is the default.

## Test plan

- [ ] Signup mode — test all three modes (open, disabled, invite code with correct/wrong code) with no email provider configured
- [ ] Admin UI — change signup mode, verify it persists across API restarts; check locked state when `DISABLE_EMAIL_SIGNUP=true`
- [ ] Invite code generator — confirm generated codes are 16 chars, visually unambiguous alphabet, no modulo bias
- [ ] Magic link — set `EMAIL_PROVIDER=resend` + key, trigger magic link from login, verify email arrives and link signs in; confirm it does not create accounts for unknown emails
- [ ] Password reset — request reset, click link, set new password; verify "contact admin" message shown when no email provider; verify expired token shows correct error
- [ ] Login page — no flash of "No account?" when signup is disabled; magic link default overridden correctly after password reset (`?reset=1`)
- [ ] Public `/api/v1/signup-settings` — does not leak invite code value; returns correct mode shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)