### PR TITLE
feat: add generic OIDC SSO login support

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -21,6 +21,23 @@ UI_URL=http://localhost:3000
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=
 
+# ── Generic OIDC login (optional) ────────────────────────────────────────────
+# Enables SSO login via any OIDC-compliant IdP (Okta, Auth0, Keycloak, Azure AD, …).
+# Create an OIDC application in your IdP and set the callback URL to:
+#   http://localhost:3000/api/auth/oauth2/callback/oidc
+# OIDC_ISSUER_URL is the base issuer URL (the `iss` claim value).
+#   Okta:       https://your-org.okta.com/oauth2/default
+#   Auth0:      https://your-tenant.auth0.com
+#   Keycloak:   https://keycloak.example.com/realms/your-realm
+#   Azure AD:   https://login.microsoftonline.com/<tenant-id>/v2.0
+# The discovery document is fetched from <OIDC_ISSUER_URL>/.well-known/openid-configuration.
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_ISSUER_URL=
+# When true, disables magic-link and GitHub/Google login for all users.
+# Useful for SSO-only deployments where user lifecycle is managed by the IdP.
+OIDC_ENFORCE=false
+
 # ── GitHub OAuth login (optional) ─────────────────────────────────────────────
 # Enables the "Continue with GitHub" button on the login page.
 # Create an OAuth App at https://github.com/settings/developers.

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth"
-import { admin, magicLink } from "better-auth/plugins"
+import { admin, magicLink, genericOAuth } from "better-auth/plugins"
 import { Pool } from "pg"
 import { passwordPolicyPlugin } from "./password"
 import { createEmailProvider } from "./email"
@@ -9,7 +9,9 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 const emailProvider = createEmailProvider()
 export const emailProviderConfigured = emailProvider !== null
 
-const magicLinkPlugin = emailProvider
+const oidcEnforce = process.env.OIDC_ENFORCE === "true"
+
+const magicLinkPlugin = emailProvider && !oidcEnforce
   ? magicLink({
       disableSignUp: true,
       sendMagicLink: async ({ email, url }) => {
@@ -23,6 +25,21 @@ const magicLinkPlugin = emailProvider
     })
   : null
 
+const oidcPlugin = process.env.OIDC_CLIENT_ID
+  ? genericOAuth({
+      config: [
+        {
+          providerId: "oidc",
+          clientId: process.env.OIDC_CLIENT_ID,
+          clientSecret: process.env.OIDC_CLIENT_SECRET!,
+          discoveryUrl: `${process.env.OIDC_ISSUER_URL}/.well-known/openid-configuration`,
+          scopes: ["openid", "profile", "email"],
+          pkce: true,
+        },
+      ],
+    })
+  : null
+
 export const coreAuthOptions = {
   advanced: {
     database: {
@@ -33,6 +50,7 @@ export const coreAuthOptions = {
     passwordPolicyPlugin(),
     admin({ adminRole: "admin", defaultRole: "developer" }),
     ...(magicLinkPlugin ? [magicLinkPlugin] : []),
+    ...(oidcPlugin ? [oidcPlugin] : []),
   ],
   emailAndPassword: {
     enabled: true,
@@ -66,7 +84,7 @@ export const auth = betterAuth({
   secret: process.env.BETTER_AUTH_SECRET,
   trustedOrigins: [process.env.UI_URL ?? "http://localhost:3000"],
   socialProviders: {
-    ...(process.env.GITHUB_CLIENT_ID
+    ...(process.env.GITHUB_CLIENT_ID && !oidcEnforce
       ? {
           github: {
             clientId: process.env.GITHUB_CLIENT_ID,
@@ -74,7 +92,7 @@ export const auth = betterAuth({
           },
         }
       : {}),
-    ...(process.env.GOOGLE_CLIENT_ID
+    ...(process.env.GOOGLE_CLIENT_ID && !oidcEnforce
       ? {
           google: {
             clientId: process.env.GOOGLE_CLIENT_ID,

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -53,7 +53,7 @@ export const coreAuthOptions = {
     ...(oidcPlugin ? [oidcPlugin] : []),
   ],
   emailAndPassword: {
-    enabled: true,
+    enabled: !oidcEnforce,
     ...(emailProvider
       ? {
           sendResetPassword: async ({ user, url }: { user: { email: string }; url: string }) => {

--- a/apps/docs/content/docs/configuration/authentication.mdx
+++ b/apps/docs/content/docs/configuration/authentication.mdx
@@ -144,10 +144,14 @@ auth:
     enforce: true
 ```
 
-When enforcement is on, the GitHub OAuth, Google OAuth, and magic-link buttons are hidden from the login page and their corresponding better-auth providers are not registered — preventing access even via direct API calls.
+When enforcement is on:
 
-<Callout type="info">
-  Enforcement applies to **all** users, including admins. If you need emergency access after an IdP outage, set `auth.oidc.enforce: false` and run `helm upgrade`. Email/password login remains available regardless of enforcement mode.
+- GitHub OAuth, Google OAuth, and magic-link buttons are hidden from the login page
+- The `/login/email` route redirects back to `/login`
+- Email/password, magic-link, and social OAuth providers are not registered in the auth backend — preventing access even via direct API calls
+
+<Callout type="warn">
+  Enforcement applies to **all** users, including admins. If you need emergency access after an IdP outage, set `auth.oidc.enforce: false` and run `helm upgrade` to restore email/password login.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/configuration/authentication.mdx
+++ b/apps/docs/content/docs/configuration/authentication.mdx
@@ -1,11 +1,11 @@
 ---
 title: Authentication providers
-description: Configure GitHub OAuth, Google OAuth, email login, magic link, and signup access control.
+description: Configure GitHub OAuth, Google OAuth, generic OIDC (SSO), email login, magic link, and signup access control.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout"
 
-canette supports three login methods: **GitHub OAuth**, **Google OAuth**, and **email/password**. All three can be active simultaneously. Social providers are hidden from the login page when not configured.
+canette supports four login methods: **GitHub OAuth**, **Google OAuth**, **generic OIDC (SSO)**, and **email/password**. All four can be active simultaneously. Social providers are hidden from the login page when not configured.
 
 ## GitHub OAuth
 
@@ -72,6 +72,83 @@ api:
 ```
 
 Once configured, a **Continue with Google** button appears on the login page.
+
+---
+
+## Generic OIDC (SSO)
+
+Generic OIDC lets users log in via your organisation's identity provider — Okta, Auth0, Keycloak, Azure AD, or any OIDC-compliant IdP. It is the recommended method for enterprise deployments where user lifecycle (onboarding, offboarding, MFA) is managed centrally.
+
+### 1. Create an OIDC application in your IdP
+
+The exact steps vary by provider, but the common fields are:
+
+- **Application type**: Web application (or equivalent)
+- **Redirect / callback URL**: `https://canette.example.com/api/auth/oauth2/callback/oidc`
+- **Scopes**: `openid`, `profile`, `email` (canette requests these automatically)
+
+Copy the **Client ID**, **Client secret**, and **Issuer URL** from the application settings.
+
+Common issuer URL formats:
+
+| Provider | Issuer URL |
+|----------|-----------|
+| Okta | `https://your-org.okta.com/oauth2/default` |
+| Auth0 | `https://your-tenant.auth0.com` |
+| Keycloak | `https://keycloak.example.com/realms/your-realm` |
+| Azure AD | `https://login.microsoftonline.com/<tenant-id>/v2.0` |
+
+The issuer URL is the base URL as returned in the `iss` claim of OIDC tokens. canette appends `/.well-known/openid-configuration` to discover the authorization and token endpoints automatically.
+
+### 2. Configure Helm
+
+```yaml
+auth:
+  oidc:
+    clientId: "<client-id>"
+    clientSecret: "<client-secret>"
+    issuerUrl: "https://your-org.okta.com/oauth2/default"
+```
+
+Or reference a pre-existing Kubernetes Secret for the client secret:
+
+```yaml
+auth:
+  oidc:
+    clientId: "<client-id>"
+    clientSecretRef:
+      name: my-oidc-secret
+      key: client-secret
+    issuerUrl: "https://your-org.okta.com/oauth2/default"
+```
+
+Once configured, a **Continue with SSO** button with a key icon appears on the login page.
+
+### Button label
+
+The button label defaults to `SSO`. Set `auth.oidc.displayName` to match your IdP's name:
+
+```yaml
+auth:
+  oidc:
+    displayName: "Okta"   # renders as "Continue with Okta"
+```
+
+### Enforcement mode
+
+When OIDC is configured, you can optionally disable all other login methods so that users must authenticate via your IdP:
+
+```yaml
+auth:
+  oidc:
+    enforce: true
+```
+
+When enforcement is on, the GitHub OAuth, Google OAuth, and magic-link buttons are hidden from the login page and their corresponding better-auth providers are not registered — preventing access even via direct API calls.
+
+<Callout type="info">
+  Enforcement applies to **all** users, including admins. If you need emergency access after an IdP outage, set `auth.oidc.enforce: false` and run `helm upgrade`. Email/password login remains available regardless of enforcement mode.
+</Callout>
 
 ---
 

--- a/apps/ui/.env.local.example
+++ b/apps/ui/.env.local.example
@@ -10,3 +10,18 @@ API_INTERNAL_URL=http://localhost:3001
 
 # Public API URL — used by client-side auth (must be reachable from the browser)
 NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# ── Login providers ───────────────────────────────────────────────────────────
+# In production these are set automatically by the Helm chart.
+# Toggle them locally to test the login page with different provider combinations.
+GITHUB_LOGIN_ENABLED=false
+GOOGLE_LOGIN_ENABLED=false
+EMAIL_LOGIN_ENABLED=true
+
+# Generic OIDC (Okta, Auth0, Keycloak, Azure AD, …)
+# Set OIDC_LOGIN_ENABLED=true to show the SSO button on the login page.
+# OIDC_DISPLAY_NAME controls the button label: "Continue with <name>".
+# OIDC_ENFORCE_ENABLED=true hides all non-OIDC options (GitHub, Google, email).
+OIDC_LOGIN_ENABLED=false
+OIDC_DISPLAY_NAME=SSO
+OIDC_ENFORCE_ENABLED=false

--- a/apps/ui/src/app/login/email/page.tsx
+++ b/apps/ui/src/app/login/email/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { CanetteLogo } from "@/components/canette-logo"
 import { EmailForm } from "./email-form"
@@ -10,6 +11,10 @@ export default async function EmailLoginPage({
 }: {
   searchParams: Promise<Record<string, string>>
 }) {
+  if (process.env.OIDC_ENFORCE_ENABLED === "true") {
+    redirect("/login")
+  }
+
   const [{ callbackURL, reset, signup }, initialSettings] = await Promise.all([
     searchParams,
     fetchSignupSettings(),

--- a/apps/ui/src/app/login/login-form.tsx
+++ b/apps/ui/src/app/login/login-form.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { signIn } from "@/lib/auth-client"
+import { authClient, signIn } from "@/lib/auth-client"
 import { Button } from "@/components/ui/button"
-import { Loader2 } from "lucide-react"
+import { KeyRound, Loader2 } from "lucide-react"
 import { GitHubIcon } from "@/components/icons/github-icon"
 import { GoogleIcon } from "@/components/icons/google-icon"
 
@@ -12,19 +12,30 @@ export function LoginForm({
   githubEnabled,
   googleEnabled,
   emailEnabled,
+  oidcEnabled,
+  oidcDisplayName,
+  oidcEnforced,
   signupEnabled,
   callbackURL,
 }: {
   githubEnabled: boolean
   googleEnabled: boolean
   emailEnabled: boolean
+  oidcEnabled: boolean
+  oidcDisplayName: string
+  oidcEnforced: boolean
   signupEnabled?: boolean
   callbackURL?: string
 }) {
   const [githubLoading, setGithubLoading] = useState(false)
   const [googleLoading, setGoogleLoading] = useState(false)
-  const hasSocialProviders = githubEnabled || googleEnabled
-  const showDivider = hasSocialProviders && emailEnabled
+  const [oidcLoading, setOidcLoading] = useState(false)
+
+  const showGithub = githubEnabled && !oidcEnforced
+  const showGoogle = googleEnabled && !oidcEnforced
+  const showEmail = emailEnabled && !oidcEnforced
+  const hasSocialProviders = showGithub || showGoogle || oidcEnabled
+  const showDivider = hasSocialProviders && showEmail
   // Reject non-relative callbackURLs to prevent open redirect attacks.
   const dest = callbackURL?.startsWith("/") ? callbackURL : "/dashboard"
   const emailHref = callbackURL
@@ -33,7 +44,22 @@ export function LoginForm({
 
   return (
     <div className="flex flex-col gap-3">
-      {githubEnabled && (
+      {oidcEnabled && (
+        <Button
+          variant="outline"
+          className="w-full gap-3"
+          disabled={oidcLoading}
+          onClick={() => {
+            setOidcLoading(true)
+            authClient.signIn.oauth2({ providerId: "oidc", callbackURL: dest })
+          }}
+        >
+          {oidcLoading ? <Loader2 className="size-4 animate-spin" /> : <KeyRound size={18} />}
+          Continue with {oidcDisplayName}
+        </Button>
+      )}
+
+      {showGithub && (
         <Button
           className="w-full gap-3 bg-[#24292f] hover:bg-[#2f3439] text-white border border-white/10"
           disabled={githubLoading}
@@ -47,7 +73,7 @@ export function LoginForm({
         </Button>
       )}
 
-      {googleEnabled && (
+      {showGoogle && (
         <Button
           variant="outline"
           className="w-full gap-3"
@@ -73,13 +99,13 @@ export function LoginForm({
         </div>
       )}
 
-      {emailEnabled && (
+      {showEmail && (
         <Button asChild variant="outline" className="w-full">
           <Link href={emailHref}>Sign in with email</Link>
         </Button>
       )}
 
-      {emailEnabled && signupEnabled && (
+      {showEmail && signupEnabled && (
         <p className="text-center text-sm text-muted-foreground">
           No account?{" "}
           <Link

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -13,9 +13,12 @@ export default async function LoginPage({
   const githubEnabled = !!process.env.GITHUB_LOGIN_ENABLED && process.env.GITHUB_LOGIN_ENABLED !== "false"
   const googleEnabled = !!process.env.GOOGLE_LOGIN_ENABLED && process.env.GOOGLE_LOGIN_ENABLED !== "false"
   const emailEnabled = process.env.EMAIL_LOGIN_ENABLED !== "false"
+  const oidcEnabled = process.env.OIDC_LOGIN_ENABLED === "true"
+  const oidcDisplayName = process.env.OIDC_DISPLAY_NAME ?? "SSO"
+  const oidcEnforced = process.env.OIDC_ENFORCE_ENABLED === "true"
   const [{ callbackURL }, signupSettings] = await Promise.all([
     searchParams,
-    emailEnabled ? fetchSignupSettings() : Promise.resolve(undefined),
+    emailEnabled && !oidcEnforced ? fetchSignupSettings() : Promise.resolve(undefined),
   ])
   const signupEnabled = signupSettings?.mode !== "disabled"
 
@@ -30,7 +33,16 @@ export default async function LoginPage({
           <CardDescription>Kubernetes Push-to-deploy Platform</CardDescription>
         </CardHeader>
         <CardContent>
-          <LoginForm githubEnabled={githubEnabled} googleEnabled={googleEnabled} emailEnabled={emailEnabled} signupEnabled={signupEnabled} callbackURL={callbackURL} />
+          <LoginForm
+            githubEnabled={githubEnabled}
+            googleEnabled={googleEnabled}
+            emailEnabled={emailEnabled}
+            oidcEnabled={oidcEnabled}
+            oidcDisplayName={oidcDisplayName}
+            oidcEnforced={oidcEnforced}
+            signupEnabled={signupEnabled}
+            callbackURL={callbackURL}
+          />
         </CardContent>
       </Card>
     </main>

--- a/apps/ui/src/lib/auth-client.ts
+++ b/apps/ui/src/lib/auth-client.ts
@@ -1,10 +1,10 @@
 import { createAuthClient } from "better-auth/react"
-import { adminClient, magicLinkClient } from "better-auth/client/plugins"
+import { adminClient, magicLinkClient, genericOAuthClient } from "better-auth/client/plugins"
 
 export const authClient = createAuthClient({
   // No baseURL — better-auth uses the current page origin, which Next.js
   // proxies to the API via the /api rewrite in next.config.ts.
-  plugins: [adminClient(), magicLinkClient()],
+  plugins: [adminClient(), magicLinkClient(), genericOAuthClient()],
 })
 
 export const { signIn, signOut, signUp, useSession, changePassword, requestPasswordReset, resetPassword } = authClient

--- a/charts/canette/templates/api/deployment.yaml
+++ b/charts/canette/templates/api/deployment.yaml
@@ -90,6 +90,32 @@ spec:
                   key: google-client-secret
                   {{- end }}
             {{- end }}
+            {{- if .Values.auth.oidc.clientId }}
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: canette-api-secrets
+                  key: oidc-client-id
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  {{- if ((.Values.auth.oidc.clientSecretRef).name) }}
+                  name: {{ .Values.auth.oidc.clientSecretRef.name }}
+                  key: {{ .Values.auth.oidc.clientSecretRef.key }}
+                  {{- else }}
+                  name: canette-api-secrets
+                  key: oidc-client-secret
+                  {{- end }}
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: canette-api-secrets
+                  key: oidc-issuer-url
+            {{- end }}
+            {{- if .Values.auth.oidc.enforce }}
+            - name: OIDC_ENFORCE
+              value: "true"
+            {{- end }}
             {{- if .Values.api.githubApp.appId }}
             - name: GITHUB_APP_ID
               valueFrom:

--- a/charts/canette/templates/api/secret.yaml
+++ b/charts/canette/templates/api/secret.yaml
@@ -44,6 +44,13 @@ stringData:
   google-client-id: {{ .Values.api.googleClientId | quote }}
   google-client-secret: {{ .Values.api.googleClientSecret | quote }}
   {{- end }}
+  {{- if .Values.auth.oidc.clientId }}
+  oidc-client-id: {{ .Values.auth.oidc.clientId | quote }}
+  oidc-issuer-url: {{ .Values.auth.oidc.issuerUrl | quote }}
+  {{- if not ((.Values.auth.oidc.clientSecretRef).name) }}
+  oidc-client-secret: {{ .Values.auth.oidc.clientSecret | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.externalDatabase.ssl.caCert }}
   database-ca-cert: {{ .Values.externalDatabase.ssl.caCert | quote }}
   {{- end }}

--- a/charts/canette/templates/ui/deployment.yaml
+++ b/charts/canette/templates/ui/deployment.yaml
@@ -45,6 +45,12 @@ spec:
               value: {{ if .Values.api.googleClientId }}"true"{{ else }}"false"{{ end }}
             - name: EMAIL_LOGIN_ENABLED
               value: {{ if .Values.api.disableEmailSignup }}"false"{{ else }}"true"{{ end }}
+            - name: OIDC_LOGIN_ENABLED
+              value: {{ if .Values.auth.oidc.clientId }}"true"{{ else }}"false"{{ end }}
+            - name: OIDC_DISPLAY_NAME
+              value: {{ .Values.auth.oidc.displayName | default "SSO" | quote }}
+            - name: OIDC_ENFORCE_ENABLED
+              value: {{ if .Values.auth.oidc.enforce }}"true"{{ else }}"false"{{ end }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/canette/values.yaml
+++ b/charts/canette/values.yaml
@@ -294,6 +294,33 @@ security:
     sbomEnabled: false
 
 # ---------------------------------------------------------------------------
+# Authentication providers
+# ---------------------------------------------------------------------------
+auth:
+  oidc:
+    # Generic OIDC provider — covers Okta, Auth0, Keycloak, Azure AD, and any
+    # OIDC-compliant IdP. Leave clientId empty to disable OIDC login.
+    clientId: ""
+    clientSecret: ""
+    # Optional: read the OIDC client secret from a pre-existing Kubernetes Secret
+    # instead of a plain value. The secret must exist in the system namespace
+    # before helm install/upgrade.
+    clientSecretRef:
+      name: ""
+      key: "oidc-client-secret"
+    # Base issuer URL as returned in the `iss` OIDC claim.
+    # e.g. https://login.okta.com/oauth2/default
+    # The discovery document is fetched from <issuerUrl>/.well-known/openid-configuration.
+    issuerUrl: ""
+    # Label shown on the login button. Defaults to "SSO".
+    # Example: "Okta", "Azure AD", "Acme SSO"
+    displayName: "SSO"
+    # When true, disables all non-OIDC authentication methods (magic-link,
+    # GitHub OAuth, Google OAuth) for all users. Set to true for SSO-only
+    # deployments where user lifecycle must be managed centrally.
+    enforce: false
+
+# ---------------------------------------------------------------------------
 # API service (Bun + Hono)
 # ---------------------------------------------------------------------------
 api:


### PR DESCRIPTION
## Summary

- Adds generic OIDC login via better-auth's `genericOAuth` plugin, covering Okta, Auth0, Keycloak, Azure AD, and any OIDC-compliant IdP
- Configured entirely through Helm values (`auth.oidc.*`) — no admin UI or database migration required
- JIT provisioning: a canette user is created automatically on first OIDC login
- Optional enforcement mode (`auth.oidc.enforce: true`) disables magic-link and GitHub/Google OAuth for all users

## Changes

- **`apps/api/src/auth/auth.ts`** — adds `genericOAuth` plugin; enforcement mode excludes other providers from the better-auth config
- **`apps/ui/src/lib/auth-client.ts`** — adds `genericOAuthClient` plugin
- **`apps/ui/src/app/login/`** — OIDC button with `KeyRound` icon, hidden when not configured; hides all other options when enforcement is on
- **`charts/canette/values.yaml`** — new `auth.oidc.*` section with `clientId`, `clientSecret`, `clientSecretRef`, `issuerUrl`, `displayName`, `enforce`
- **Helm templates** — wires credentials into the API pod as env vars; sets `OIDC_LOGIN_ENABLED`, `OIDC_DISPLAY_NAME`, `OIDC_ENFORCE_ENABLED` on the UI pod
- **`.env.example` files** — documents the four new env vars with example issuer URLs for common IdPs

## Test plan

- [ ] Deploy with a local Keycloak or Dex instance, set `auth.oidc.*` Helm values, verify login flow and JIT user creation
- [ ] Verify `OIDC_DISPLAY_NAME` customises the button label correctly
- [ ] Set `auth.oidc.enforce: true` and verify GitHub/Google/email options disappear from the login page
- [ ] Verify existing GitHub/Google/magic-link login still works when OIDC is configured without enforcement

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)